### PR TITLE
Fix Expo Router warning by moving theme context

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ For deeper detail see [`docs/Phase_0.md`](docs/Phase_0.md) and [`docs/WORKFLOW.m
 ┣ 📜tsconfig.json
 ┣ 📂app
 ┃ ┣ 📜index.tsx
-┃ ┣ 📜_theme.tsx
 ┃ ┣ 📜tokens.json
 ┃ ┗ 📜_layout.tsx
 ┣ 📂assets
@@ -162,7 +161,8 @@ For deeper detail see [`docs/Phase_0.md`](docs/Phase_0.md) and [`docs/WORKFLOW.m
 ┣ 📂lib
 ┃ ┣ 📜database.types.ts
 ┃ ┣ 📜gamesApi.ts
-┃ ┗ 📜supabase.ts
+┃ ┣ 📜supabase.ts
+┃ ┗ 📜theme.tsx
 ┣ 📂stores
 ┃ ┗ 📜useRegionStore.ts
 ┣ 📂Docs

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,7 +4,7 @@ import { Stack } from 'expo-router';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
 
-import { ThemeProvider } from './_theme';
+import { ThemeProvider } from '../lib/theme';
 
 export default function Layout() {
   return (

--- a/components/RegionPicker.tsx
+++ b/components/RegionPicker.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { View, Text, Pressable, Modal, StyleSheet } from 'react-native';
 import { ChevronDown, Check } from 'lucide-react-native';
 
-import { useTheme } from '../app/_theme';
+import { useTheme } from '../lib/theme';
 import { useRegionStore, Region } from '../stores/useRegionStore';
 
 const REGION_OPTIONS: Region[] = ['AU', 'US', 'EU'];

--- a/components/SettingsRow.tsx
+++ b/components/SettingsRow.tsx
@@ -1,6 +1,6 @@
 // components/SettingsRow.tsx
 import { Switch, Text, View, StyleSheet } from 'react-native';
-import { useTheme } from '../app/_theme';
+import { useTheme } from '../lib/theme';
 
 export default function CvdSwitch() {
   const { isCvd, toggleCvd, tokens } = useTheme();

--- a/folder_tree.md
+++ b/folder_tree.md
@@ -9,7 +9,6 @@
 ┣ 📜tsconfig.json
 ┣ 📂app
 ┃ ┣ 📜index.tsx
-┃ ┣ 📜_theme.tsx
 ┃ ┣ 📜tokens.json
 ┃ ┗ 📜_layout.tsx
 ┣ 📂assets
@@ -37,7 +36,8 @@
 ┣ 📂lib
 ┃ ┣ 📜database.types.ts
 ┃ ┣ 📜gamesApi.ts
-┃ ┗ 📜supabase.ts
+┃ ┣ 📜supabase.ts
+┃ ┗ 📜theme.tsx
 ┣ 📂stores
 ┃ ┗ 📜useRegionStore.ts
 ┣ 📂Docs

--- a/lib/theme.tsx
+++ b/lib/theme.tsx
@@ -1,13 +1,12 @@
-// app/_theme.tsx
+// lib/theme.tsx
 // -----------------------------------------------------------------------------
 // Central theme context (light / dark + Colour‑Vision Deficiency toggle)
 // -----------------------------------------------------------------------------
 // Usage:
-//   import { useTheme } from "../app/_theme";
+//   import { useTheme } from "../lib/theme";
 //   const { tokens, toggleCvd } = useTheme();
 //
 // * Never import tokens.json directly in components – always go through context
-// * The leading underscore keeps Expo Router from treating this as a route file
 // -----------------------------------------------------------------------------
 import React, {
   createContext,
@@ -18,7 +17,7 @@ import React, {
 } from "react";
 import { useColorScheme } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import baseTokens from "./tokens.json";
+import baseTokens from "../app/tokens.json";
 
 /* -------------------------------------------------------------------------- */
 /*                              Type definitions                               */


### PR DESCRIPTION
## Summary
- move `app/_theme.tsx` to `lib/theme.tsx`
- update imports to use new theme context path
- refresh README and `folder_tree.md`

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6857b1136610832fa2b8b2669add4e1a