### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "splash": {
       "image": "./assets/splash-icon.png",

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -5,9 +5,13 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
 import Header from '../components/Header';
 import RegionPicker from '../components/RegionPicker';
+import CvdSwitch from '../components/SettingsRow';
+import ThemeSwitch from '../components/ThemeSwitch';
+import { useTheme } from '../lib/theme';
 import { supabase } from '../lib/supabase';
 
 export default function IndexScreen() {
+  const { tokens } = useTheme();
   const [gameCount, setGameCount] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -26,6 +30,25 @@ export default function IndexScreen() {
       });
   }, []);
 
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: tokens.color.brand.primary.value,
+      padding: 16,
+    },
+    debugContainer: {
+      marginTop: 20,
+    },
+    debugText: {
+      color: tokens.color.neutral['0'].value,
+      fontSize: 18,
+    },
+    errorText: {
+      color: '#FF6666',
+      fontSize: 18,
+    },
+  });
+
   return (
     <SafeAreaView style={styles.container}>
       <StatusBar style="light" />
@@ -40,25 +63,8 @@ export default function IndexScreen() {
           <Text style={styles.debugText}>🎲 {gameCount} games loaded</Text>
         )}
       </View>
+      <CvdSwitch />
+      <ThemeSwitch />
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#0C244B',
-    padding: 16,
-  },
-  debugContainer: {
-    marginTop: 20,
-  },
-  debugText: {
-    color: '#FFFFFF',
-    fontSize: 18,
-  },
-  errorText: {
-    color: '#FF6666',
-    fontSize: 18,
-  },
-});

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -7,7 +7,7 @@ import {
   Pressable,
   GestureResponderEvent,
 } from 'react-native';
-import tokens from '../app/tokens.json';
+import { useTheme } from '../lib/theme';
 
 export interface Game {
   id: string;
@@ -22,6 +22,34 @@ type GameCardProps = {
 };
 
 export default function GameCard({ game, onPress }: GameCardProps) {
+  const { tokens } = useTheme();
+  const styles = StyleSheet.create({
+    card: {
+      flex: 1,
+      backgroundColor: tokens.color.neutral['0'].value,
+      borderRadius: tokens.radius.md.value,
+      padding: tokens.spacing['4'].value,
+      alignItems: 'center',
+      margin: tokens.spacing['2'].value,
+    },
+    logo: {
+      width: 48,
+      height: 48,
+      marginBottom: tokens.spacing['2'].value,
+    },
+    name: {
+      fontSize: tokens.typography.fontSizes.md.value,
+      fontWeight: '500',
+      color: tokens.color.brand.primary.value,
+      marginBottom: tokens.spacing['1'].value,
+    },
+    jackpot: {
+      fontSize: tokens.typography.fontSizes.sm.value,
+      fontWeight: '400',
+      color: tokens.color.neutral['600'].value,
+    },
+  });
+
   return (
     <Pressable
       style={styles.card}
@@ -40,29 +68,3 @@ export default function GameCard({ game, onPress }: GameCardProps) {
   );
 }
 
-const styles = StyleSheet.create({
-  card: {
-    flex: 1,
-    backgroundColor: tokens.color.neutral['0'].value,
-    borderRadius: tokens.radius.md.value,
-    padding: tokens.spacing['4'].value,
-    alignItems: 'center',
-    margin: tokens.spacing['2'].value,
-  },
-  logo: {
-    width: 48,
-    height: 48,
-    marginBottom: tokens.spacing['2'].value,
-  },
-  name: {
-    fontSize: tokens.typography.fontSizes.md.value,
-    fontWeight: '500',
-    color: tokens.color.brand.primary.value,
-    marginBottom: tokens.spacing['1'].value,
-  },
-  jackpot: {
-    fontSize: tokens.typography.fontSizes.sm.value,
-    fontWeight: '400',
-    color: tokens.color.neutral['600'].value,
-  },
-});

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,9 +1,24 @@
 /* ---------- Header.tsx ---------- */
-import { StatusBar } from 'expo-status-bar';
 import { View, Text, StyleSheet, Platform } from 'react-native';
-import tokens from '../app/tokens.json';
+import { useTheme } from '../lib/theme';
 
 export default function Header() {
+  const { tokens } = useTheme();
+  const styles = StyleSheet.create({
+    container: {
+      backgroundColor: tokens.color.brand.primary.value,
+      height: TOP_BAR_HEIGHT,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    title: {
+      fontFamily: tokens.typography.fontFamilies.base.value,
+      fontSize: tokens.typography.fontSizes.lg.value,
+      color: tokens.color.neutral['0'].value,
+      fontWeight: '700',
+    },
+  });
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Powerpick</Text>
@@ -13,17 +28,3 @@ export default function Header() {
 
 const TOP_BAR_HEIGHT = Platform.select({ ios: 56, default: 56 });
 
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: tokens.color.brand.primary.value,
-    height: TOP_BAR_HEIGHT,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  title: {
-    fontFamily: tokens.typography.fontFamilies.base.value,
-    fontSize: tokens.typography.fontSizes.lg.value,
-    color: tokens.color.neutral['0'].value,
-    fontWeight: '700',
-  },
-});

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -1,0 +1,21 @@
+import { Switch, Text, View, StyleSheet } from 'react-native';
+import { useTheme } from '../lib/theme';
+
+export default function ThemeSwitch() {
+  const { scheme, toggleScheme, tokens } = useTheme();
+  return (
+    <View style={styles.row}>
+      <Text style={[styles.label, { color: tokens.color.brand.primary.value }]}>Dark mode</Text>
+      <Switch
+        value={scheme === 'dark'}
+        onValueChange={toggleScheme}
+        thumbColor={tokens.color.brand.accent.value}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: { flexDirection: 'row', justifyContent: 'space-between', padding: 16 },
+  label: { fontSize: 16 },
+});


### PR DESCRIPTION
## Summary
- enable dynamic `userInterfaceStyle`
- add light/dark scheme persistence and toggler
- use theme tokens in more components
- expose a Dark mode switch on the main screen

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6857b55ffe6c832f9981fad869d363c7