### PR TITLE
[fix]: rename component to SettingsRow

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -5,7 +5,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
 import Header from '../components/Header';
 import RegionPicker from '../components/RegionPicker';
-import CvdSwitch from '../components/SettingsRow';
+import SettingsRow from '../components/SettingsRow';
 import ThemeSwitch from '../components/ThemeSwitch';
 import { useTheme } from '../lib/theme';
 import { supabase } from '../lib/supabase';
@@ -63,7 +63,7 @@ export default function IndexScreen() {
           <Text style={styles.debugText}>🎲 {gameCount} games loaded</Text>
         )}
       </View>
-      <CvdSwitch />
+      <SettingsRow />
       <ThemeSwitch />
     </SafeAreaView>
   );

--- a/components/SettingsRow.tsx
+++ b/components/SettingsRow.tsx
@@ -2,7 +2,7 @@
 import { Switch, Text, View, StyleSheet } from 'react-native';
 import { useTheme } from '../lib/theme';
 
-export default function CvdSwitch() {
+export default function SettingsRow() {
   const { isCvd, toggleCvd, tokens } = useTheme();
   return (
     <View style={styles.row}>


### PR DESCRIPTION
## Summary
- rename the component inside `SettingsRow.tsx` to `SettingsRow`
- update imports and usage in `app/index.tsx`

## Testing
- `npm run format` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm test -- --coverage` *(fails: 1 test suite failed)*

------
https://chatgpt.com/codex/tasks/task_e_6857c59bd5c0832fb744cd62e9b88fa2