### PR TITLE
[fix]: add supabase mock for Index test

### DIFF
--- a/app/__tests__/Index.test.tsx
+++ b/app/__tests__/Index.test.tsx
@@ -10,6 +10,14 @@ jest.mock('expo-constants', () => ({
   },
 }));
 
+// Mock supabase client to avoid real network requests
+jest.mock('../../lib/supabase', () => {
+  const from = jest.fn(() => ({
+    select: jest.fn().mockResolvedValue({ count: 1, data: [], error: null }),
+  }));
+  return { supabase: { from } };
+});
+
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { Provider as PaperProvider } from 'react-native-paper';


### PR DESCRIPTION
## Summary
- mock supabase `from().select()` in `Index.test.tsx` to avoid network requests

## Testing
- `npm run format` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm test -- --coverage` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c5b6f624832fa9f3c378247f3c02