### PR TITLE
[feat]: unify Game interface and fetching

### DIFF
--- a/app/__tests__/Index.test.tsx
+++ b/app/__tests__/Index.test.tsx
@@ -10,13 +10,10 @@ jest.mock('expo-constants', () => ({
   },
 }));
 
-// Mock supabase client to avoid real network requests
-jest.mock('../../lib/supabase', () => {
-  const from = jest.fn(() => ({
-    select: jest.fn().mockResolvedValue({ count: 1, data: [], error: null }),
-  }));
-  return { supabase: { from } };
-});
+// Mock fetchGames to avoid real network requests
+jest.mock('../../lib/gamesApi', () => ({
+  fetchGames: jest.fn().mockResolvedValue([]),
+}));
 
 import React from 'react';
 import { render } from '@testing-library/react-native';

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -5,9 +5,8 @@ import { StatusBar } from 'expo-status-bar';
 import Header from '../components/Header';
 import RegionPicker from '../components/RegionPicker';
 import { useTheme } from '../lib/theme';
-import { supabase } from '../lib/supabase';
 import GameGrid from '../components/GameGrid';
-import { Game } from '../components/GameCard';
+import { Game, fetchGames } from '../lib/gamesApi';
 import { useRouter } from 'expo-router';
 
 export default function IndexScreen() {
@@ -18,19 +17,10 @@ export default function IndexScreen() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchGames = async () => {
+    const loadGames = async () => {
       try {
-        const { data, error } = await supabase
-          .from('games')
-          .select('id, name, logo_url, jackpot')
-          .returns<Game[]>();
-
-        if (error) {
-          console.error('Supabase error:', error);
-          setError(error.message);
-        } else {
-          setGames(data ?? []);
-        }
+        const data = await fetchGames();
+        setGames(data);
       } catch (err) {
         console.error('Unexpected fetch error:', err);
         setError((err as Error).message);
@@ -39,7 +29,7 @@ export default function IndexScreen() {
       }
     };
 
-    fetchGames();
+    loadGames();
   }, []);
 
   const handleSelectGame = (game: Game) => {

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -8,13 +8,7 @@ import {
   GestureResponderEvent,
 } from 'react-native';
 import { useTheme } from '../lib/theme';
-
-export type Game = {
-  id: string;
-  name: string;
-  logo_url: string; // ✅ matches DB column, not camelCase
-  jackpot: number;
-};
+import { Game } from '../lib/gamesApi';
 
 type GameCardProps = {
   game: Game;
@@ -57,17 +51,16 @@ export default function GameCard({ game, onPress }: GameCardProps) {
       accessibilityRole="button"
       accessibilityLabel={`Open ${game.name} options`}
     >
-    <Image
-      source={
-        game.logo_url
-          ? { uri: game.logo_url }
-          : require('../assets/placeholder.png')
-  }
-  style={styles.logo}
-  resizeMode="contain"
-/>
+      <Image
+        source={
+          game.logoUrl
+            ? { uri: game.logoUrl }
+            : require('../assets/placeholder.png')
+        }
+        style={styles.logo}
+        resizeMode="contain"
+      />
 
-      
       <Text style={styles.name}>{game.name}</Text>
       <Text style={styles.jackpot}>{game.jackpot}</Text>
     </Pressable>

--- a/components/GameGrid.tsx
+++ b/components/GameGrid.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FlatList, View, StyleSheet } from 'react-native';
-import GameCard, { Game } from './GameCard';
+import GameCard from './GameCard';
+import { Game } from '../lib/gamesApi';
 
 type GameGridProps = {
   games: Game[];

--- a/lib/gamesApi.ts
+++ b/lib/gamesApi.ts
@@ -25,6 +25,6 @@ export async function fetchGames(): Promise<Game[]> {
     id: row.id,
     name: row.name,
     logoUrl: row.logo_url,
-    jackpot: `$${(row.jackpot as number).toLocaleString()}`,
+    jackpot: `$${Number(row.jackpot).toLocaleString()}`,
   }));
 }


### PR DESCRIPTION
## Summary
- unify `Game` interface in `lib/gamesApi.ts`
- convert jackpots via `Number()`
- update `GameCard`, `GameGrid`, and `IndexScreen` to use the new interface
- call `fetchGames` from `IndexScreen` instead of duplicating the query
- adjust tests for the new fetch function

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run format` *(fails: Missing script)*
- `npm test -- --coverage` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685875af3380832f9f185573d4acbf20