### PR TITLE
[fix]: typed parameter for setRegion

### DIFF
--- a/stores/useRegionStore.ts
+++ b/stores/useRegionStore.ts
@@ -10,5 +10,5 @@ interface RegionState {
 
 export const useRegionStore = create<RegionState>((set) => ({
   region: 'AU',
-  setRegion: (r) => set({ region: r }),
+  setRegion: (r: Region) => set({ region: r }),
 }));


### PR DESCRIPTION
## Summary
- specify parameter type for `setRegion`

## Testing
- `npm run format` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm test -- --coverage` *(fails: jest not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685d163468f8832fbd699764ce95f8d5