### PR TITLE
[feat][fix][chore]: improve test coverage

### DIFF
--- a/app/__tests__/GameCard.test.tsx
+++ b/app/__tests__/GameCard.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import { Image } from "react-native";
+import { Provider as PaperProvider } from "react-native-paper";
+import { ThemeProvider } from "../../lib/theme";
+import GameCard from "../../components/GameCard";
+
+jest.mock("../../assets/placeholder.png", () => 1);
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <PaperProvider>
+    <ThemeProvider>{children}</ThemeProvider>
+  </PaperProvider>
+);
+
+describe("GameCard", () => {
+  const baseGame = {
+    id: "1",
+    name: "Powerball",
+    logoUrl: "http://example.com/logo.png",
+    jackpot: "$1,000",
+  };
+
+  test("renders jackpot and handles press", () => {
+    const onPress = jest.fn();
+    const { getByText, getByRole } = render(
+      <GameCard game={baseGame} onPress={onPress} />,
+      { wrapper: Wrapper },
+    );
+
+    expect(getByText("$1,000")).toBeTruthy();
+    fireEvent.press(getByRole("button"));
+    expect(onPress).toHaveBeenCalled();
+  });
+
+  test("shows placeholder when no logo url", () => {
+    const { UNSAFE_getByType } = render(
+      <GameCard game={{ ...baseGame, logoUrl: "" }} onPress={() => {}} />,
+      { wrapper: Wrapper },
+    );
+
+    expect(UNSAFE_getByType(Image).props.source).toBe(1);
+  });
+});

--- a/app/__tests__/GameGrid.test.tsx
+++ b/app/__tests__/GameGrid.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import { Provider as PaperProvider } from "react-native-paper";
+import { ThemeProvider } from "../../lib/theme";
+import GameGrid from "../../components/GameGrid";
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <PaperProvider>
+    <ThemeProvider>{children}</ThemeProvider>
+  </PaperProvider>
+);
+
+describe("GameGrid", () => {
+  const games = [
+    { id: "1", name: "Game 1", logoUrl: "url1", jackpot: "$1" },
+    { id: "2", name: "Game 2", logoUrl: "url2", jackpot: "$2" },
+  ];
+
+  test("renders games and triggers selection", () => {
+    const onSelect = jest.fn();
+    const { getByLabelText } = render(
+      <GameGrid games={games} onSelectGame={onSelect} />,
+      { wrapper: Wrapper },
+    );
+
+    fireEvent.press(getByLabelText("Open Game 2 options"));
+    expect(onSelect).toHaveBeenCalledWith(games[1]);
+  });
+});

--- a/app/__tests__/RegionPicker.test.tsx
+++ b/app/__tests__/RegionPicker.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react-native";
+import { Provider as PaperProvider } from "react-native-paper";
+import { ThemeProvider } from "../../lib/theme";
+import RegionPicker from "../../components/RegionPicker";
+import { useRegionStore } from "../../stores/useRegionStore";
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <PaperProvider>
+    <ThemeProvider>{children}</ThemeProvider>
+  </PaperProvider>
+);
+
+describe("RegionPicker", () => {
+  beforeEach(() => {
+    useRegionStore.setState({ region: "AU" });
+  });
+
+  test("changes region when option selected", async () => {
+    const { getByText, queryByText } = render(<RegionPicker />, {
+      wrapper: Wrapper,
+    });
+    fireEvent.press(getByText("Australia"));
+
+    const option = getByText("USA");
+    fireEvent.press(option);
+
+    await waitFor(() => expect(useRegionStore.getState().region).toBe("US"));
+    expect(queryByText("Australia")).toBeNull();
+    expect(getByText("USA")).toBeTruthy();
+  });
+});

--- a/lib/__tests__/gamesApi.test.ts
+++ b/lib/__tests__/gamesApi.test.ts
@@ -1,0 +1,54 @@
+import { fetchGames } from "../gamesApi";
+import { supabase } from "../supabase";
+
+jest.mock("../supabase", () => ({
+  supabase: {
+    from: jest.fn(),
+    storage: { from: jest.fn() },
+  },
+}));
+
+const fromMock = supabase.from as jest.Mock;
+const storageFromMock = supabase.storage.from as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("fetchGames", () => {
+  test("returns formatted games on success", async () => {
+    const selectMock = jest.fn().mockResolvedValue({
+      data: [
+        { id: "1", name: "Powerball", logo_url: "logo.png", jackpot: "1000" },
+      ],
+      error: null,
+    });
+    fromMock.mockReturnValue({ select: selectMock });
+    storageFromMock.mockReturnValue({
+      getPublicUrl: jest.fn().mockReturnValue({
+        data: { publicUrl: "https://cdn.example.com/logo.png" },
+      }),
+    });
+
+    const games = await fetchGames();
+
+    expect(games).toEqual([
+      {
+        id: "1",
+        name: "Powerball",
+        logoUrl: "https://cdn.example.com/logo.png",
+        jackpot: "$1,000",
+      },
+    ]);
+    expect(fromMock).toHaveBeenCalledWith("games");
+    expect(selectMock).toHaveBeenCalledWith("id, name, logo_url, jackpot");
+  });
+
+  test("throws when Supabase returns an error", async () => {
+    const err = new Error("boom");
+    const selectMock = jest.fn().mockResolvedValue({ data: null, error: err });
+    fromMock.mockReturnValue({ select: selectMock });
+
+    await expect(fetchGames()).rejects.toThrow(err);
+  });
+});


### PR DESCRIPTION
## Summary
- add API tests mocking Supabase responses
- test GameCard press/placeholder logic
- test GameGrid selection handling
- test RegionPicker modal interactions

## Testing
- `npm run format`
- `npm run lint` *(fails: react-native lint errors)*
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_685d485be848832f8894b248a035f74d