### PR TITLE
[fix]: consolidate jest setup arrays

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,10 +1,11 @@
 // jest.config.cjs
 module.exports = {
   preset: 'jest-expo',
-  setupFiles: ['./jestSetup.cjs'],
-  setupFiles: ['./jestSetupMocks.cjs'],
-  setupFilesAfterEnv: ['./jestSetupAfterEnv.cjs'],
-  setupFilesAfterEnv: ['@testing-library/react-native/extend-expect'],
+  setupFiles: ['./jestSetup.cjs', './jestSetupMocks.cjs'],
+  setupFilesAfterEnv: [
+    './jestSetupAfterEnv.cjs',
+    '@testing-library/react-native/extend-expect',
+  ],
   testEnvironment: 'jsdom',
   transform: {
     '^.+\\.(js|jsx|ts|tsx)$': 'babel-jest'

--- a/jestSetup.cjs
+++ b/jestSetup.cjs
@@ -19,8 +19,5 @@ jest.mock('@supabase/supabase-js', () => {
   };
 });
 
-// 3. Load React Native Testing Library matchers
-require('@testing-library/jest-native/extend-expect');
-
-// 4. Silence all console.error calls (prevents “Cannot log after tests are done”)
+// Silence all console.error calls (prevents “Cannot log after tests are done”)
 console.error = jest.fn();


### PR DESCRIPTION
## Summary
- consolidate `setupFiles` and `setupFilesAfterEnv` arrays
- remove duplicate matcher require from `jestSetup.cjs`

## Testing
- `npm run format`
- `npm run lint` *(fails: react-native/no-color-literals, no-inline-styles, etc.)*
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685d48347cd8832f8748308c104083e0