### PR TITLE
[fix]: add PNG module declaration

### DIFF
--- a/assets.d.ts
+++ b/assets.d.ts
@@ -1,0 +1,4 @@
+declare module "*.png" {
+  const value: string;
+  export default value;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "resolveJsonModule": true,
     "jsx": "react-native"
   },
-  "include": ["**/*.ts", "**/*.tsx"],
+  "include": ["**/*.ts", "**/*.tsx", "**/*.d.ts"],
   "extends": "expo/tsconfig.base"
 }


### PR DESCRIPTION
## Summary
- declare PNG modules to satisfy the TypeScript compiler
- include `*.d.ts` in `tsconfig.json`

## Testing
- `yarn install --offline`
- `npm run format`
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685dbe90a444832fae0d6b2442eb0114