### PR TITLE
[feat][fix]: game-specific number generation

### DIFF
--- a/app/__tests__/GameOptions.test.tsx
+++ b/app/__tests__/GameOptions.test.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "../../lib/theme";
 import GameOptionsScreen from "../../app/game/[id]/options";
 import * as generator from "../../lib/generator";
 import { useGeneratedNumbersStore } from "../../stores/useGeneratedNumbersStore";
+import { useGamesStore } from "../../stores/useGamesStore";
 
 jest.mock("expo-router", () => ({
   useRouter: () => ({ back: jest.fn() }),
@@ -21,13 +22,19 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 
 describe("GameOptionsScreen", () => {
   beforeEach(() => {
-    (generator.generateSet as jest.Mock).mockReturnValue([1, 2, 3]);
+    (generator.generateSet as jest.Mock).mockReset();
+    (generator.generateSet as jest.Mock)
+      .mockReturnValueOnce([1, 2, 3, 4, 5, 6, 7])
+      .mockReturnValueOnce([8]);
     useGeneratedNumbersStore.setState({ sets: {} });
+    useGamesStore.setState({
+      games: [{ id: "1", name: "Powerball", logoUrl: "", jackpot: "$0" }],
+    });
   });
 
   test("generates and displays numbers", () => {
     const { getByText } = render(<GameOptionsScreen />, { wrapper: Wrapper });
     fireEvent.press(getByText("Generate Numbers"));
-    expect(getByText("1 - 2 - 3")).toBeTruthy();
+    expect(getByText("1 - 2 - 3 - 4 - 5 - 6 - 7 - 8")).toBeTruthy();
   });
 });

--- a/app/game/[id]/options.tsx
+++ b/app/game/[id]/options.tsx
@@ -5,6 +5,8 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { useTheme } from "../../../lib/theme";
 import { generateSet } from "../../../lib/generator";
 import { useGeneratedNumbersStore } from "../../../stores/useGeneratedNumbersStore";
+import { gameConfigs } from "../../../lib/gameConfigs";
+import { useGamesStore } from "../../../stores/useGamesStore";
 
 export default function GameOptionsScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -12,9 +14,28 @@ export default function GameOptionsScreen() {
   const router = useRouter();
   const [current, setCurrent] = useState<number[]>([]);
   const saveNumbers = useGeneratedNumbersStore((s) => s.saveNumbers);
+  const game = useGamesStore((s) => (id ? s.getGame(id) : undefined));
+  const config = game ? gameConfigs[game.name] : undefined;
 
   const handleGenerate = () => {
-    const nums = generateSet({ maxNumber: 35, pickCount: 6 });
+    if (!config) return;
+    const nums = generateSet({
+      maxNumber: config.mainMax,
+      pickCount: config.mainCount,
+    });
+    if (config.suppCount) {
+      nums.push(
+        ...generateSet({
+          maxNumber: config.suppMax ?? config.mainMax,
+          pickCount: config.suppCount,
+        }),
+      );
+    }
+    if (config.powerballMax) {
+      nums.push(
+        ...generateSet({ maxNumber: config.powerballMax, pickCount: 1 }),
+      );
+    }
     setCurrent(nums);
     if (id) saveNumbers(id, nums);
   };

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -8,6 +8,7 @@ import { useTheme } from "../lib/theme";
 import GameGrid from "../components/GameGrid";
 import { Game, fetchGames } from "../lib/gamesApi";
 import { useRouter } from "expo-router";
+import { useGamesStore } from "../stores/useGamesStore";
 
 const ERROR_COLOR = "#FF6666";
 
@@ -17,12 +18,14 @@ export default function IndexScreen() {
   const [games, setGames] = useState<Game[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const setGamesStore = useGamesStore((s) => s.setGames);
 
   useEffect(() => {
     const loadGames = async () => {
       try {
         const data = await fetchGames();
         setGames(data);
+        setGamesStore(data);
       } catch (err) {
         console.error("Unexpected fetch error:", err);
         setError((err as Error).message);

--- a/lib/gameConfigs.ts
+++ b/lib/gameConfigs.ts
@@ -1,0 +1,15 @@
+export interface GameConfig {
+  mainMax: number;
+  mainCount: number;
+  suppCount?: number;
+  suppMax?: number;
+  powerballMax?: number;
+}
+
+export const gameConfigs: Record<string, GameConfig> = {
+  Powerball: { mainMax: 35, mainCount: 7, powerballMax: 20 },
+  "Saturday Lotto": { mainMax: 45, mainCount: 6, suppCount: 2, suppMax: 45 },
+  "Oz Lotto": { mainMax: 45, mainCount: 7, suppCount: 2, suppMax: 45 },
+  "Set for Life": { mainMax: 44, mainCount: 7, suppCount: 2, suppMax: 44 },
+  "Weekday Windfall": { mainMax: 45, mainCount: 6 },
+};

--- a/stores/useGamesStore.ts
+++ b/stores/useGamesStore.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+import type { Game } from "../lib/gamesApi";
+
+interface GamesState {
+  games: Game[];
+  setGames: (games: Game[]) => void;
+  getGame: (id: string) => Game | undefined;
+}
+
+export const useGamesStore = create<GamesState>((set, get) => ({
+  games: [],
+  setGames: (games: Game[]) => set({ games }),
+  getGame: (id: string) => get().games.find((g) => g.id === id),
+}));


### PR DESCRIPTION
## Summary
- add a store for loading game data globally
- map game names to number generation rules
- use those rules in Game Options screen
- update GameOptions test for new behaviour

## Testing
- `npm run lint` *(fails: `cross-env` not found)*
- `npm test -- --coverage` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9b35ac30832fb5726ae9d1f3d283