### PR TITLE
[fix]: fallback config for number generation

### DIFF
--- a/app/game/[id]/options.tsx
+++ b/app/game/[id]/options.tsx
@@ -5,7 +5,7 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { useTheme } from "../../../lib/theme";
 import { generateSet } from "../../../lib/generator";
 import { useGeneratedNumbersStore } from "../../../stores/useGeneratedNumbersStore";
-import { gameConfigs } from "../../../lib/gameConfigs";
+import { gameConfigs, GameConfig } from "../../../lib/gameConfigs";
 import { useGamesStore } from "../../../stores/useGamesStore";
 
 export default function GameOptionsScreen() {
@@ -18,23 +18,26 @@ export default function GameOptionsScreen() {
   const config = game ? gameConfigs[game.name] : undefined;
 
   const handleGenerate = () => {
-    if (!config) return;
+    const cfg: GameConfig =
+      config ??
+      ({
+        mainMax: 50,
+        mainCount: 6,
+      } as GameConfig);
     const nums = generateSet({
-      maxNumber: config.mainMax,
-      pickCount: config.mainCount,
+      maxNumber: cfg.mainMax,
+      pickCount: cfg.mainCount,
     });
-    if (config.suppCount) {
+    if (cfg.suppCount) {
       nums.push(
         ...generateSet({
-          maxNumber: config.suppMax ?? config.mainMax,
-          pickCount: config.suppCount,
+          maxNumber: cfg.suppMax ?? cfg.mainMax,
+          pickCount: cfg.suppCount,
         }),
       );
     }
-    if (config.powerballMax) {
-      nums.push(
-        ...generateSet({ maxNumber: config.powerballMax, pickCount: 1 }),
-      );
+    if (cfg.powerballMax) {
+      nums.push(...generateSet({ maxNumber: cfg.powerballMax, pickCount: 1 }));
     }
     setCurrent(nums);
     if (id) saveNumbers(id, nums);

--- a/lib/csvParser.ts
+++ b/lib/csvParser.ts
@@ -33,10 +33,9 @@ export function csvParseRows(text: string): string[][] {
 
   function token(): string | typeof EOL | typeof EOF {
     if (eof) return EOF;
-    if (eol) return (eol = false), EOL;
-    let i: number,
-      j = I,
-      c: number;
+    if (eol) return ((eol = false), EOL);
+    let i: number, c: number;
+    const j = I;
     if (text.charCodeAt(j) === QUOTE) {
       while (
         (I++ < N && text.charCodeAt(I) !== QUOTE) ||
@@ -58,7 +57,7 @@ export function csvParseRows(text: string): string[][] {
       } else if (c !== DELIMITER) continue;
       return text.slice(j, i);
     }
-    return (eof = true), text.slice(j, N);
+    return ((eof = true), text.slice(j, N));
   }
 
   while ((t = token()) !== EOF) {

--- a/lib/syncDraws.ts
+++ b/lib/syncDraws.ts
@@ -109,8 +109,6 @@ async function syncGame(game: Game): Promise<void> {
     if (error) console.error("UPSERT ERROR:", game.table, error);
     const inserted = data as DrawRecord[] | null;
     console.log(`✅ ${game.table}: ${inserted?.length ?? 0} rows`);
-
-
   } catch (err) {
     console.error("SYNC ERROR:", game.table, err);
   }
@@ -127,7 +125,7 @@ export async function syncAllGames(): Promise<void> {
 export { parseCsv, extractNumbers };
 
 // 10) If run directly, invoke sync
-if (import.meta.url === `file://${process.argv[1]}`) {
+const isDirectRun = typeof require !== "undefined" && require.main === module;
+if (isDirectRun) {
   syncAllGames().catch((err) => console.error("FATAL:", err));
 }
-


### PR DESCRIPTION
## Summary
- fallback generator defaults when game config missing
- allow syncDraws CLI via require.main
- fix lint issue in csv parser

## Testing
- `yarn install --offline`
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685eb253b0c0832fae20a40b4b757d3a