### PR TITLE
[feat][fix]: case-insensitive game config lookup

### DIFF
--- a/app/__tests__/GameOptions.test.tsx
+++ b/app/__tests__/GameOptions.test.tsx
@@ -28,7 +28,7 @@ describe("GameOptionsScreen", () => {
       .mockReturnValueOnce([8]);
     useGeneratedNumbersStore.setState({ sets: {} });
     useGamesStore.setState({
-      games: [{ id: "1", name: "Powerball", logoUrl: "", jackpot: "$0" }],
+      games: [{ id: "1", name: "pOwErBaLl", logoUrl: "", jackpot: "$0" }],
     });
   });
 

--- a/lib/__tests__/generator.test.ts
+++ b/lib/__tests__/generator.test.ts
@@ -1,4 +1,5 @@
 import { generateSet } from "../generator";
+import { getGameConfig } from "../gameConfigs";
 
 test("generateSet returns numbers within range", () => {
   const seq = [0.24, 0.34, 0.44, 0.54, 0.64, 0.74];
@@ -13,4 +14,11 @@ test("generateSet throws when pickCount exceeds maxNumber", () => {
   expect(() => generateSet({ maxNumber: 3, pickCount: 5 })).toThrow(
     "pickCount cannot exceed maxNumber",
   );
+});
+
+test("getGameConfig handles mixed-case names and aliases", () => {
+  const canonical = getGameConfig("Powerball");
+  expect(getGameConfig("powerball")).toEqual(canonical);
+  expect(getGameConfig("PoWeRbAlL")).toEqual(canonical);
+  expect(getGameConfig("sat lotto")).toEqual(getGameConfig("Saturday Lotto"));
 });

--- a/lib/gameConfigs.ts
+++ b/lib/gameConfigs.ts
@@ -6,21 +6,45 @@ export interface GameConfig {
   powerballMax?: number;
 }
 
+export function normalizeName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
 export const gameConfigs: Record<string, GameConfig> = {
-  Powerball: { mainMax: 35, mainCount: 7, powerballMax: 20 },
-  "Saturday Lotto": { mainMax: 45, mainCount: 6, suppCount: 2, suppMax: 45 },
-  "Oz Lotto": { mainMax: 45, mainCount: 7, suppCount: 2, suppMax: 45 },
-  "Set for Life": { mainMax: 44, mainCount: 7, suppCount: 2, suppMax: 44 },
-  "Weekday Windfall": { mainMax: 45, mainCount: 6 },
+  [normalizeName("Powerball")]: {
+    mainMax: 35,
+    mainCount: 7,
+    powerballMax: 20,
+  },
+  [normalizeName("Saturday Lotto")]: {
+    mainMax: 45,
+    mainCount: 6,
+    suppCount: 2,
+    suppMax: 45,
+  },
+  [normalizeName("Oz Lotto")]: {
+    mainMax: 45,
+    mainCount: 7,
+    suppCount: 2,
+    suppMax: 45,
+  },
+  [normalizeName("Set for Life")]: {
+    mainMax: 44,
+    mainCount: 7,
+    suppCount: 2,
+    suppMax: 44,
+  },
+  [normalizeName("Weekday Windfall")]: { mainMax: 45, mainCount: 6 },
 };
 
 const nameAliases: Record<string, string> = {
-  "Sat Lotto": "Saturday Lotto",
-  "Weekday WF": "Weekday Windfall",
-  "Set 4 Life": "Set for Life",
+  [normalizeName("Sat Lotto")]: normalizeName("Saturday Lotto"),
+  [normalizeName("Weekday WF")]: normalizeName("Weekday Windfall"),
+  [normalizeName("Set 4 Life")]: normalizeName("Set for Life"),
 };
 
 export function getGameConfig(name: string): GameConfig | undefined {
-  const canonical = nameAliases[name] ?? name;
+  const normalized = normalizeName(name);
+  const canonical = nameAliases[normalized] ?? normalized;
   return gameConfigs[canonical];
 }


### PR DESCRIPTION
## Summary
- add `normalizeName` helper in `gameConfigs` and use it for lookups
- support mixed-case names in tests
- cover alias and case-insensitive lookups

## Testing
- `yarn install --offline`
- `npm run format`
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685f2c4e4df0832fbe3a8ce199ea48c0