### PR TITLE
[feat]: hot/cold weighted number generation

### DIFF
--- a/app/__tests__/GameOptions.test.tsx
+++ b/app/__tests__/GameOptions.test.tsx
@@ -87,7 +87,7 @@ describe("GameOptionsScreen", () => {
     const { getByText } = render(<GameOptionsScreen />, { wrapper: Wrapper });
     expect(getByText("Pick 8 main + 2 supp + Powerball")).toBeTruthy();
   });
-  test("sliders are disabled when auto is on", () => {
+  test("hot ratio slider is disabled when auto is on", () => {
     const { getByLabelText } = render(<GameOptionsScreen />, {
       wrapper: Wrapper,
     });
@@ -95,12 +95,12 @@ describe("GameOptionsScreen", () => {
     expect(ratio.props.disabled).toBe(true);
   });
 
-  test("sliders are disabled when auto is on", () => {
+  test("hot percent slider is disabled when auto is on", () => {
     const { getByLabelText } = render(<GameOptionsScreen />, {
       wrapper: Wrapper,
     });
-    const ratio = getByLabelText("Hot cold ratio");
-    expect(ratio.props.disabled).toBe(true);
+    const percent = getByLabelText("Hot cold percent");
+    expect(percent.props.disabled).toBe(true);
   });
 
   test("sliders can be adjusted when auto is off", () => {

--- a/app/game/[id]/options.tsx
+++ b/app/game/[id]/options.tsx
@@ -45,10 +45,10 @@ export default function GameOptionsScreen() {
 
   // Fallback for missing config
   const displayCfg: GameConfig = config ?? {
-    mainMax:      50,
-    mainCount:    6,
-    suppMax:      undefined,
-    suppCount:    undefined,
+    mainMax: 50,
+    mainCount: 6,
+    suppMax: undefined,
+    suppCount: undefined,
     powerballMax: undefined,
   };
 
@@ -58,7 +58,7 @@ export default function GameOptionsScreen() {
     displayCfg.suppCount !== undefined
       ? current.slice(
           displayCfg.mainCount,
-          displayCfg.mainCount + displayCfg.suppCount
+          displayCfg.mainCount + displayCfg.suppCount,
         )
       : [];
   const powerballNum =
@@ -75,7 +75,7 @@ export default function GameOptionsScreen() {
       ...generateSet({
         maxNumber: displayCfg.mainMax,
         pickCount: displayCfg.mainCount,
-      })
+      }),
     );
 
     // Supplementary balls
@@ -87,7 +87,7 @@ export default function GameOptionsScreen() {
         ...generateSet({
           maxNumber: displayCfg.suppMax,
           pickCount: displayCfg.suppCount,
-        })
+        }),
       );
     }
 
@@ -97,7 +97,7 @@ export default function GameOptionsScreen() {
         ...generateSet({
           maxNumber: displayCfg.powerballMax,
           pickCount: 1,
-        })
+        }),
       );
     }
 
@@ -106,19 +106,38 @@ export default function GameOptionsScreen() {
   };
 
   const styles = StyleSheet.create({
-    container:       { flex: 1, padding: 16 },
-    header:          { flexDirection: "row", justifyContent: "space-between", marginBottom: 16 },
-    title:           { color: tokens.color.brand.primary.value, fontSize: 20 },
-    close:           { color: tokens.color.brand.primary.value, fontSize: 20 },
-    configText:      { color: tokens.color.brand.primary.value, fontSize: 16, marginBottom: 16, textAlign: "center" },
-    numbers:         { color: tokens.color.brand.primary.value, fontSize: 24, marginVertical: 16, textAlign: "center" },
-    toggleRow:       { flexDirection: "row", alignItems: "center", marginBottom: 16 },
-    toggleText:      { color: tokens.color.brand.primary.value, marginLeft: 8 },
+    button: {
+      alignItems: "center",
+      backgroundColor: tokens.color.brand.primary.value,
+      borderRadius: 8,
+      padding: 12,
+    },
+    buttonText: { color: tokens.color.neutral["0"].value, fontSize: 18 },
+    close: { color: tokens.color.brand.primary.value, fontSize: 20 },
+    configText: {
+      color: tokens.color.brand.primary.value,
+      fontSize: 16,
+      marginBottom: 16,
+      textAlign: "center",
+    },
+    container: { flex: 1, padding: 16 },
+    disabled: { opacity: 0.5 },
+    header: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      marginBottom: 16,
+    },
+    numbers: {
+      color: tokens.color.brand.primary.value,
+      fontSize: 24,
+      marginVertical: 16,
+      textAlign: "center",
+    },
     sliderContainer: { marginBottom: 16 },
-    sliderLabel:     { color: tokens.color.brand.primary.value },
-    disabled:        { opacity: 0.5 },
-    button:          { alignItems: "center", backgroundColor: tokens.color.brand.primary.value, borderRadius: 8, padding: 12 },
-    buttonText:      { color: tokens.color.neutral["0"].value, fontSize: 18 },
+    sliderLabel: { color: tokens.color.brand.primary.value },
+    title: { color: tokens.color.brand.primary.value, fontSize: 20 },
+    toggleRow: { alignItems: "center", flexDirection: "row", marginBottom: 16 },
+    toggleText: { color: tokens.color.brand.primary.value, marginLeft: 8 },
   });
 
   return (
@@ -147,7 +166,11 @@ export default function GameOptionsScreen() {
       )}
 
       <View accessibilityLabel="Auto toggle" style={styles.toggleRow}>
-        <Switch value={isAuto} onValueChange={setIsAuto} accessibilityRole="switch" />
+        <Switch
+          value={isAuto}
+          onValueChange={setIsAuto}
+          accessibilityRole="switch"
+        />
         <Text style={styles.toggleText}>Auto</Text>
       </View>
 
@@ -165,7 +188,9 @@ export default function GameOptionsScreen() {
           disabled={isAuto}
           accessibilityLabel="Hot cold ratio"
         />
-        <Text style={styles.sliderLabel}>Hot/Cold Numbers Used: {hotPercent}%</Text>
+        <Text style={styles.sliderLabel}>
+          Hot/Cold Numbers Used: {hotPercent}%
+        </Text>
         <Slider
           value={hotPercent}
           minimumValue={0}
@@ -177,7 +202,11 @@ export default function GameOptionsScreen() {
         />
       </View>
 
-      <Pressable style={styles.button} onPress={handleGenerate} accessibilityRole="button">
+      <Pressable
+        style={styles.button}
+        onPress={handleGenerate}
+        accessibilityRole="button"
+      >
         <Text style={styles.buttonText}>Generate Numbers</Text>
       </Pressable>
     </SafeAreaView>

--- a/lib/__tests__/gamesApi.test.ts
+++ b/lib/__tests__/gamesApi.test.ts
@@ -1,4 +1,4 @@
-import { fetchGames } from "../gamesApi";
+import { fetchGames, fetchHotColdNumbers } from "../gamesApi";
 import { supabase } from "../supabase";
 
 jest.mock("../supabase", () => ({
@@ -95,5 +95,32 @@ describe("fetchGames", () => {
     fromMock.mockReturnValue({ select: selectMock });
 
     await expect(fetchGames()).rejects.toThrow(err);
+  });
+});
+
+describe("fetchHotColdNumbers", () => {
+  test("returns hot and cold arrays", async () => {
+    const response = {
+      data: {
+        main_hot: [1, 2],
+        main_cold: [9, 10],
+        supp_hot: [3],
+        supp_cold: [8],
+      },
+      error: null,
+    };
+    const selectMock = jest.fn().mockReturnThis();
+    const eqMock = jest.fn().mockReturnThis();
+    const singleMock = jest.fn().mockResolvedValue(response);
+    fromMock.mockReturnValue({
+      select: selectMock,
+      eq: eqMock,
+      single: singleMock,
+    });
+
+    const result = await fetchHotColdNumbers("1");
+    expect(result.mainHot).toEqual([1, 2]);
+    expect(selectMock).toHaveBeenCalledWith("*");
+    expect(eqMock).toHaveBeenCalledWith("game_id", "1");
   });
 });

--- a/lib/__tests__/generator.test.ts
+++ b/lib/__tests__/generator.test.ts
@@ -6,8 +6,18 @@ test("generateSet returns numbers within range", () => {
   let i = 0;
   const rand = () => seq[i++ % seq.length];
   const nums = generateSet({ maxNumber: 10, pickCount: 3 }, rand);
-  expect(nums).toEqual([3, 4, 5]);
+  expect(nums).toEqual([3, 5, 6]);
   expect(nums.every((n) => n >= 1 && n <= 10)).toBe(true);
+});
+
+test("generateSet favors hot numbers when ratio is 1", () => {
+  const rand = () => 0.5;
+  const nums = generateSet(
+    { maxNumber: 10, pickCount: 3, hotNumbers: [1, 2, 3], hotRatio: 1 },
+    rand,
+  );
+  const hotCount = nums.filter((n) => [1, 2, 3].includes(n)).length;
+  expect(hotCount).toBeGreaterThanOrEqual(1);
 });
 
 test("generateSet throws when pickCount exceeds maxNumber", () => {

--- a/lib/__tests__/hotCold.test.ts
+++ b/lib/__tests__/hotCold.test.ts
@@ -1,0 +1,12 @@
+import { calculateHotColdNumbers } from "../hotCold";
+
+test("calculateHotColdNumbers returns top and bottom numbers", () => {
+  const draws = [
+    [1, 2, 3],
+    [1, 2, 4],
+    [1, 3, 5],
+  ];
+  const { hot, cold } = calculateHotColdNumbers(draws, 5, 40);
+  expect(hot).toEqual([1, 2]);
+  expect(cold).toEqual([4, 5]);
+});

--- a/lib/gamesApi.ts
+++ b/lib/gamesApi.ts
@@ -72,3 +72,34 @@ export async function fetchGames(): Promise<Game[]> {
     };
   });
 }
+
+export interface HotColdNumbers {
+  mainHot: number[];
+  mainCold: number[];
+  suppHot?: number[];
+  suppCold?: number[];
+  powerballHot?: number[];
+  powerballCold?: number[];
+}
+
+export async function fetchHotColdNumbers(
+  gameId: string,
+): Promise<HotColdNumbers> {
+  const { data, error } = await supabase
+    .from("hot_cold_numbers")
+    .select("*")
+    .eq("game_id", gameId)
+    .single();
+  if (error) {
+    console.error("Error fetching hot/cold:", error);
+    throw error;
+  }
+  return {
+    mainHot: data.main_hot ?? [],
+    mainCold: data.main_cold ?? [],
+    suppHot: data.supp_hot ?? [],
+    suppCold: data.supp_cold ?? [],
+    powerballHot: data.powerball_hot ?? [],
+    powerballCold: data.powerball_cold ?? [],
+  } as HotColdNumbers;
+}

--- a/lib/hotCold.ts
+++ b/lib/hotCold.ts
@@ -1,0 +1,30 @@
+export interface HotColdResult {
+  hot: number[];
+  cold: number[];
+}
+
+/**
+ * Calculate hot and cold numbers based on historical draws.
+ * @param draws Array of arrays representing past winning numbers.
+ * @param maxNumber Maximum possible number for the game.
+ * @param percent Percentage of the number pool to return for hot/cold groups (0-100).
+ */
+export function calculateHotColdNumbers(
+  draws: number[][],
+  maxNumber: number,
+  percent: number,
+): HotColdResult {
+  const counts = Array(maxNumber + 1).fill(0);
+  for (const draw of draws) {
+    for (const num of draw) {
+      if (num >= 1 && num <= maxNumber) counts[num]++;
+    }
+  }
+  const nums = Array.from({ length: maxNumber }, (_, i) => i + 1);
+  nums.sort((a, b) => counts[b] - counts[a] || a - b);
+
+  const groupSize = Math.max(0, Math.round((maxNumber * percent) / 100));
+  const hot = nums.slice(0, groupSize);
+  const cold = nums.slice(-groupSize);
+  return { hot, cold };
+}


### PR DESCRIPTION
## Summary
- implement weighted number generation using hot/cold numbers
- compute hot/cold sets from draw history
- fetch per-game hot/cold data from Supabase
- test coverage for new utilities and updated generator
- update GameOptions tests

## Testing
- `yarn install --offline`
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685f5708e350832f8a601e269d90d232