### PR TITLE
[feat]: add draw history and hot-cold screens

### DIFF
--- a/app/__tests__/GameOptions.test.tsx
+++ b/app/__tests__/GameOptions.test.tsx
@@ -20,10 +20,16 @@ jest.mock("expo-constants", () => ({
   },
 }));
 
-jest.mock("expo-router", () => ({
-  useRouter: () => ({ back: jest.fn() }),
-  useLocalSearchParams: () => ({ id: "1" }),
-}));
+jest.mock("expo-router", () => {
+  const push = jest.fn();
+  return {
+    __esModule: true,
+    useRouter: () => ({ back: jest.fn(), push }),
+    useLocalSearchParams: () => ({ id: "1" }),
+    pushMock: push,
+  };
+});
+import { pushMock } from "expo-router";
 
 jest.mock("../../lib/generator");
 jest.mock("../../lib/gamesApi");
@@ -112,5 +118,19 @@ describe("GameOptionsScreen", () => {
     const ratio = getByLabelText("Hot cold ratio");
     fireEvent(ratio, "valueChange", 60);
     expect(ratio.props.value).toBe(60);
+  });
+
+  test("navigation buttons are rendered", () => {
+    const { getByText } = render(<GameOptionsScreen />, { wrapper: Wrapper });
+    expect(getByText("Last 10 Draws")).toBeTruthy();
+    expect(getByText("Hot & Cold Numbers")).toBeTruthy();
+  });
+
+  test("pressing navigation buttons pushes routes", () => {
+    const { getByText } = render(<GameOptionsScreen />, { wrapper: Wrapper });
+    fireEvent.press(getByText("Last 10 Draws"));
+    fireEvent.press(getByText("Hot & Cold Numbers"));
+    expect(pushMock).toHaveBeenCalledWith("/game/1/draws");
+    expect(pushMock).toHaveBeenCalledWith("/game/1/hotcold");
   });
 });

--- a/app/game/[id]/draws.tsx
+++ b/app/game/[id]/draws.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from "react";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { View, Text, FlatList, StyleSheet } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { useTheme } from "../../../lib/theme";
+import { fetchRecentDraws, DrawResult } from "../../../lib/gamesApi";
+import { useGamesStore } from "../../../stores/useGamesStore";
+
+export default function DrawsScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { tokens } = useTheme();
+  const [draws, setDraws] = useState<DrawResult[]>([]);
+  const game = useGamesStore((s) => (id ? s.getGame(id) : undefined));
+
+  useEffect(() => {
+    const load = async () => {
+      if (game) {
+        const data = await fetchRecentDraws(game.name);
+        setDraws(data);
+      }
+    };
+    load();
+  }, [game]);
+
+  if (!game) return null;
+
+  const styles = StyleSheet.create({
+    container: { flex: 1, padding: 16 },
+    item: { paddingVertical: 8 },
+    text: { color: tokens.color.brand.primary.value, fontSize: 16 },
+    title: {
+      color: tokens.color.brand.primary.value,
+      fontSize: 20,
+      marginBottom: 16,
+      textAlign: "center",
+    },
+  });
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>{game.name} Last 10 Draws</Text>
+      <FlatList
+        data={draws}
+        keyExtractor={(item) => String(item.draw_number)}
+        renderItem={({ item }) => (
+          <View style={styles.item}>
+            <Text style={styles.text}>
+              #{item.draw_number} - {item.draw_date} -{" "}
+              {item.winning_numbers.join(" - ")}
+            </Text>
+          </View>
+        )}
+      />
+    </SafeAreaView>
+  );
+}

--- a/app/game/[id]/hotcold.tsx
+++ b/app/game/[id]/hotcold.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from "react";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Text, StyleSheet } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { useTheme } from "../../../lib/theme";
+import { fetchHotColdNumbers, HotColdNumbers } from "../../../lib/gamesApi";
+import { useGamesStore } from "../../../stores/useGamesStore";
+
+export default function HotColdScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { tokens } = useTheme();
+  const [numbers, setNumbers] = useState<HotColdNumbers | null>(null);
+  const game = useGamesStore((s) => (id ? s.getGame(id) : undefined));
+
+  useEffect(() => {
+    const load = async () => {
+      if (id) {
+        const data = await fetchHotColdNumbers(id);
+        setNumbers(data);
+      }
+    };
+    load();
+  }, [id]);
+
+  if (!game) return null;
+
+  const styles = StyleSheet.create({
+    container: { flex: 1, padding: 16 },
+    text: {
+      color: tokens.color.brand.primary.value,
+      fontSize: 16,
+      marginBottom: 8,
+    },
+    title: {
+      color: tokens.color.brand.primary.value,
+      fontSize: 20,
+      marginBottom: 16,
+      textAlign: "center",
+    },
+  });
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>{game.name} Hot & Cold Numbers</Text>
+      {numbers ? (
+        <>
+          <Text style={styles.text}>Hot: {numbers.mainHot.join(" - ")}</Text>
+          {numbers.suppHot?.length ? (
+            <Text style={styles.text}>
+              Supp Hot: {numbers.suppHot.join(" - ")}
+            </Text>
+          ) : null}
+          {numbers.powerballHot?.length ? (
+            <Text style={styles.text}>
+              Powerball Hot: {numbers.powerballHot.join(" - ")}
+            </Text>
+          ) : null}
+          <Text style={styles.text}>Cold: {numbers.mainCold.join(" - ")}</Text>
+          {numbers.suppCold?.length ? (
+            <Text style={styles.text}>
+              Supp Cold: {numbers.suppCold.join(" - ")}
+            </Text>
+          ) : null}
+          {numbers.powerballCold?.length ? (
+            <Text style={styles.text}>
+              Powerball Cold: {numbers.powerballCold.join(" - ")}
+            </Text>
+          ) : null}
+        </>
+      ) : (
+        <Text style={styles.text}>Loading…</Text>
+      )}
+    </SafeAreaView>
+  );
+}

--- a/app/game/[id]/options.tsx
+++ b/app/game/[id]/options.tsx
@@ -112,6 +112,7 @@ export default function GameOptionsScreen() {
       borderRadius: 8,
       padding: 12,
     },
+    buttonSpacing: { marginTop: 12 },
     buttonText: { color: tokens.color.neutral["0"].value, fontSize: 18 },
     close: { color: tokens.color.brand.primary.value, fontSize: 20 },
     configText: {
@@ -208,6 +209,22 @@ export default function GameOptionsScreen() {
         accessibilityRole="button"
       >
         <Text style={styles.buttonText}>Generate Numbers</Text>
+      </Pressable>
+
+      <Pressable
+        style={[styles.button, styles.buttonSpacing]}
+        onPress={() => router.push(`/game/${id}/draws`)}
+        accessibilityRole="button"
+      >
+        <Text style={styles.buttonText}>Last 10 Draws</Text>
+      </Pressable>
+
+      <Pressable
+        style={[styles.button, styles.buttonSpacing]}
+        onPress={() => router.push(`/game/${id}/hotcold`)}
+        accessibilityRole="button"
+      >
+        <Text style={styles.buttonText}>Hot & Cold Numbers</Text>
       </Pressable>
     </SafeAreaView>
   );

--- a/lib/__tests__/gamesApi.test.ts
+++ b/lib/__tests__/gamesApi.test.ts
@@ -1,4 +1,4 @@
-import { fetchGames, fetchHotColdNumbers } from "../gamesApi";
+import { fetchGames, fetchHotColdNumbers, fetchRecentDraws } from "../gamesApi";
 import { supabase } from "../supabase";
 
 jest.mock("../supabase", () => ({
@@ -122,5 +122,29 @@ describe("fetchHotColdNumbers", () => {
     expect(result.mainHot).toEqual([1, 2]);
     expect(selectMock).toHaveBeenCalledWith("*");
     expect(eqMock).toHaveBeenCalledWith("game_id", "1");
+  });
+});
+
+describe("fetchRecentDraws", () => {
+  test("requests latest draws", async () => {
+    const selectMock = jest.fn().mockReturnThis();
+    const orderMock = jest.fn().mockReturnThis();
+    const limitMock = jest.fn().mockResolvedValue({
+      data: [
+        { draw_number: 1, draw_date: "2020-01-01", winning_numbers: [1, 2, 3] },
+      ],
+      error: null,
+    });
+    fromMock.mockReturnValue({
+      select: selectMock,
+      order: orderMock,
+      limit: limitMock,
+    });
+
+    const result = await fetchRecentDraws("Powerball");
+    expect(fromMock).toHaveBeenCalledWith("powerball_draws");
+    expect(orderMock).toHaveBeenCalledWith("draw_number", { ascending: false });
+    expect(limitMock).toHaveBeenCalledWith(10);
+    expect(result[0].draw_number).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- add fetchRecentDraws API helper
- add hot/cold numbers screen
- add draw history screen
- link new screens from Game Options
- test navigation buttons and API helper

## Testing
- `yarn install --offline`
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685f63a33a68832f99fee012334061bb