### PR TITLE
[feat]: add hot-cold sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ For deeper detail see [`Docs/Phase_0.md`](Docs/Phase_0.md) and [`Docs/WORKFLOW.m
 2. **Environment** – duplicate `.env.example` as `.env` (the file is gitignored) and add your Supabase keys and Slack webhooks.
 3. **Database** – run `/supabase/init.sql` or `supabase db reset` then `supabase start`.
 4. **Sync Draw History** – `npm run sync:draws` fetches the latest results for all games.
-5. **Run the App**
+5. **Update Hot & Cold Numbers** – `npm run sync:hotcold` populates analytics.
+6. **Run the App**
    \| Platform | Command | Notes |
    \| -------- | ---------------------- | ----- |
    \| Mobile | `npm run start` | Scan QR in **Expo Go** |

--- a/lib/__tests__/gamesApi.test.ts
+++ b/lib/__tests__/gamesApi.test.ts
@@ -166,27 +166,3 @@ describe("fetchRecentDraws", () => {
     expect(result[0].draw_number).toBe(1);
   });
 });
-
-describe("fetchRecentDraws", () => {
-  test("requests latest draws", async () => {
-    const selectMock = jest.fn().mockReturnThis();
-    const orderMock = jest.fn().mockReturnThis();
-    const limitMock = jest.fn().mockResolvedValue({
-      data: [
-        { draw_number: 1, draw_date: "2020-01-01", winning_numbers: [1, 2, 3] },
-      ],
-      error: null,
-    });
-    fromMock.mockReturnValue({
-      select: selectMock,
-      order: orderMock,
-      limit: limitMock,
-    });
-
-    const result = await fetchRecentDraws("Powerball");
-    expect(fromMock).toHaveBeenCalledWith("powerball_draws");
-    expect(orderMock).toHaveBeenCalledWith("draw_number", { ascending: false });
-    expect(limitMock).toHaveBeenCalledWith(10);
-    expect(result[0].draw_number).toBe(1);
-  });
-});

--- a/lib/__tests__/syncHotCold.test.ts
+++ b/lib/__tests__/syncHotCold.test.ts
@@ -1,0 +1,30 @@
+describe("computeHotCold", () => {
+  test("calculates hot and cold numbers from rows", () => {
+    process.env.SUPABASE_URL = "http://localhost";
+    process.env.SUPABASE_ANON_KEY = "anon";
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const { computeHotCold } = require("../syncHotCold");
+    const rows = [
+      { winning_numbers: [1, 2, 3], supplementary_numbers: [7], powerball: 9 },
+      { winning_numbers: [1, 2, 4], supplementary_numbers: [8], powerball: 10 },
+      { winning_numbers: [1, 3, 5], supplementary_numbers: [7], powerball: 9 },
+    ];
+    const record = computeHotCold(
+      rows,
+      {
+        id: 1,
+        table: "t",
+        main_max: 5,
+        supp_max: 10,
+        powerball_max: 10,
+      },
+      40,
+    );
+    expect(record.main_hot).toEqual([1, 2]);
+    expect(record.main_cold).toEqual([4, 5]);
+    expect(record.supp_hot).toEqual([7, 8, 1, 2]);
+    expect(record.supp_cold).toEqual([5, 6, 9, 10]);
+    expect(record.powerball_hot).toEqual([9, 10, 1, 2]);
+    expect(record.powerball_cold).toEqual([5, 6, 7, 8]);
+  });
+});

--- a/lib/syncHotCold.ts
+++ b/lib/syncHotCold.ts
@@ -1,0 +1,124 @@
+import * as dotenv from "dotenv";
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { calculateHotColdNumbers } from "./hotCold";
+
+dotenv.config();
+
+const SUPABASE_URL: string = process.env.SUPABASE_URL ?? "";
+const SUPABASE_ANON_KEY: string = process.env.SUPABASE_ANON_KEY ?? "";
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  throw new Error("Supabase credentials are missing");
+}
+
+const supabase: SupabaseClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+interface GameConfig {
+  id: number;
+  table: string;
+  main_max: number;
+  supp_max?: number | null;
+  powerball_max?: number | null;
+}
+
+const GAME_TABLES: Record<number, string> = {
+  5130: "oz_lotto_draws",
+  5132: "powerball_draws",
+  5127: "saturday_lotto_draws",
+  5237: "set_for_life_draws",
+  5303: "weekday_windfall_draws",
+};
+
+interface DrawRow {
+  winning_numbers: number[];
+  supplementary_numbers?: number[] | null;
+  powerball?: number | null;
+}
+
+export interface HotColdRecord {
+  game_id: number;
+  main_hot: number[];
+  main_cold: number[];
+  supp_hot?: number[];
+  supp_cold?: number[];
+  powerball_hot?: number[];
+  powerball_cold?: number[];
+}
+
+export function computeHotCold(
+  rows: DrawRow[],
+  cfg: GameConfig,
+  percent = 20,
+): HotColdRecord {
+  const mainDraws = rows.map((r) => r.winning_numbers);
+  const { hot: main_hot, cold: main_cold } = calculateHotColdNumbers(
+    mainDraws,
+    cfg.main_max,
+    percent,
+  );
+
+  const record: HotColdRecord = {
+    game_id: cfg.id,
+    main_hot,
+    main_cold,
+  };
+
+  if (cfg.supp_max) {
+    const suppDraws = rows.flatMap((r) => r.supplementary_numbers ?? []);
+    const grouped = suppDraws.map((n) => [n]);
+    const { hot, cold } = calculateHotColdNumbers(
+      grouped,
+      cfg.supp_max,
+      percent,
+    );
+    record.supp_hot = hot;
+    record.supp_cold = cold;
+  }
+
+  if (cfg.powerball_max) {
+    const pbDraws = rows
+      .map((r) => r.powerball)
+      .filter((n): n is number => typeof n === "number");
+    const grouped = pbDraws.map((n) => [n]);
+    const { hot, cold } = calculateHotColdNumbers(
+      grouped,
+      cfg.powerball_max,
+      percent,
+    );
+    record.powerball_hot = hot;
+    record.powerball_cold = cold;
+  }
+
+  return record;
+}
+
+async function updateGameHotCold(game: GameConfig): Promise<void> {
+  const { data, error } = await supabase
+    .from(game.table)
+    .select<DrawRow>("winning_numbers, supplementary_numbers, powerball");
+  if (error) throw error;
+  const rows = data ?? [];
+  const record = computeHotCold(rows, game);
+
+  const { error: upsertError } = await supabase
+    .from("hot_cold_numbers")
+    .upsert(record, { onConflict: "game_id" });
+  if (upsertError) throw upsertError;
+  console.log(`✅ Updated hot/cold for game ${game.id}`);
+}
+
+export async function syncAllHotCold(): Promise<void> {
+  const { data, error } = await supabase
+    .from("games")
+    .select("id, main_max, supp_max, powerball_max");
+  if (error) throw error;
+  const games = (data ?? []) as GameConfig[];
+  for (const g of games) {
+    const table = GAME_TABLES[g.id];
+    if (!table) continue;
+    await updateGameHotCold({ ...g, table });
+  }
+}
+
+if (require.main === module) {
+  syncAllHotCold().catch((err) => console.error("FATAL:", err));
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "test": "jest --coverage",
-    "sync-draws": "node --loader ts-node/esm --no-warnings lib/syncDraws.ts"
+    "sync-draws": "node --loader ts-node/esm --no-warnings lib/syncDraws.ts",
+    "sync-hotcold": "node --loader ts-node/esm --no-warnings lib/syncHotCold.ts"
   },
   "dependencies": {
     "@babel/runtime": "^7.27.6",


### PR DESCRIPTION
## Summary
- compute and store hot/cold numbers from draw history
- add script `sync-hotcold` to run calculation
- document step for updating hot/cold numbers
- fix duplicate test titles
- test `computeHotCold` logic

## Testing
- `yarn install --offline`
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685f6f20e0ec832f9d873414bd436051