### PR TITLE
[fix]: ensure sync-draws script works in Node

### DIFF
--- a/lib/syncDraws.ts
+++ b/lib/syncDraws.ts
@@ -1,5 +1,6 @@
 import * as dotenv from "dotenv";
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import fetch from "cross-fetch";
 
 // 1) Load environment variables
 dotenv.config();
@@ -75,6 +76,7 @@ async function syncGame(game: Game): Promise<void> {
     const csv = await res.text();
     const rows = parseCsv(csv);
     console.log(`DEBUG: Parsed rows = ${rows.length}`);
+    if (rows[0]) console.log("DEBUG: First row =", rows[0]);
 
     const records: DrawRecord[] = rows.map((row) => {
       const draw_number = Number(row["Draw number"]);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-native-screens": "~4.11.1",
     "react-native-url-polyfill": "^2.0.0",
     "react-native-web": "^0.20.0",
+    "cross-fetch": "^3.2.0",
     "supabase": "^2.26.9",
     "webpack": "^5.99.9",
     "zustand": "^5.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3555,7 +3555,7 @@ cross-env@^7.0.3:
   dependencies:
     cross-spawn "^7.0.1"
 
-cross-fetch@^3.1.5:
+cross-fetch@^3.1.5, cross-fetch@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.2.0.tgz#34e9192f53bc757d6614304d9e5e6fb4edb782e3"
   integrity sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==


### PR DESCRIPTION
## Summary
- use cross-fetch in syncDraws so `fetch` is defined in older Node
- log the first row parsed for easier debugging
- add cross-fetch dependency

## Testing
- `npm run format`
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685fc7467300832f9cdd967c9011097c