### PR TITLE
Add indexes and caching improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,10 @@ For deeper detail see [`Docs/Phase_0.md`](Docs/Phase_0.md) and [`Docs/WORKFLOW.m
 
 2. **Environment** – duplicate `.env.example` as `.env` (the file is gitignored) and add your Supabase keys and Slack webhooks.
 3. **Database** – run `/supabase/init.sql` or `supabase db reset` then `supabase start`.
-4. **Sync Draw History** – `npm run sync:draws` fetches the latest results for all games.
-5. **Update Hot & Cold Numbers** – `npm run sync:hotcold` populates analytics.
-6. **Run the App**
+4. **Create Indexes** – `node lib/createIndexes.ts` prints SQL. Execute it via the Supabase SQL editor.
+5. **Sync Draw History** – `npm run sync:draws` fetches the latest results for all games.
+6. **Update Hot & Cold Numbers** – `npm run sync:hotcold` populates analytics.
+7. **Run the App**
    \| Platform | Command | Notes |
    \| -------- | ---------------------- | ----- |
    \| Mobile | `npm run start` | Scan QR in **Expo Go** |

--- a/lib/createIndexes.ts
+++ b/lib/createIndexes.ts
@@ -1,0 +1,10 @@
+const sql = `\
+CREATE INDEX IF NOT EXISTS draws_game_id_draw_number ON public.draws (game_id, draw_number);
+CREATE INDEX IF NOT EXISTS draw_results_draw_id ON public.draw_results (draw_id);
+CREATE INDEX IF NOT EXISTS ball_types_game_id ON public.ball_types (game_id);
+`;
+export default sql;
+
+if (typeof require !== "undefined" && require.main === module) {
+  console.log(sql.trim());
+}


### PR DESCRIPTION
## Summary
- add in-memory caches for game data and draw APIs
- batch database writes in syncDraws and run games in parallel
- expose SQL for creating indexes
- document running createIndexes script
- test caching behaviour

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_685fdb1c5158832f8423f47efed6d8aa