### PR TITLE
fix header layout and hide expo titles

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,14 +4,15 @@ import { Stack } from "expo-router";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
 import { ThemeProvider } from "../lib/theme";
+import Header from "../components/Header";
 
 export default function Layout() {
   return (
     <ThemeProvider>
       <SafeAreaProvider>
         <StatusBar style="auto" />
-        <Stack>
-          <Stack.Screen name="index" options={{ headerShown: false }} />
+        <Stack screenOptions={{ header: () => <Header /> }}>
+          <Stack.Screen name="index" />
         </Stack>
       </SafeAreaProvider>
     </ThemeProvider>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
-import Header from "../components/Header";
 import RegionPicker from "../components/RegionPicker";
 import ComingSoon from "../components/ComingSoon";
 import { useTheme } from "../lib/theme";
@@ -68,7 +67,6 @@ export default function IndexScreen() {
   return (
     <SafeAreaView style={styles.container}>
       <StatusBar style="light" />
-      <Header />
       <RegionPicker />
 
       {region === "AU" ? (

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -23,7 +23,7 @@ export default function Header() {
     },
     logo: {
       height: 80,
-      width: 500,
+      width: 160,
     },
   });
 


### PR DESCRIPTION
## Summary
- shrink header logo to fit the screen
- use the logo header for all stack screens
- remove duplicate header on the index page

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_685fe512af14832fafd563dd1cc88054