### PR TITLE
Fix TypeScript test types

### DIFF
--- a/app/__tests__/GameCard.test.tsx
+++ b/app/__tests__/GameCard.test.tsx
@@ -19,6 +19,11 @@ describe("GameCard", () => {
     name: "Powerball",
     logoUrl: "http://example.com/logo.png",
     jackpot: "$1,000",
+    mainMax: null,
+    mainCount: null,
+    suppCount: null,
+    suppMax: null,
+    powerballMax: null,
   };
 
   test("renders jackpot and handles press", () => {

--- a/app/__tests__/GameGrid.test.tsx
+++ b/app/__tests__/GameGrid.test.tsx
@@ -12,8 +12,28 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 
 describe("GameGrid", () => {
   const games = [
-    { id: "1", name: "Game 1", logoUrl: "url1", jackpot: "$1" },
-    { id: "2", name: "Game 2", logoUrl: "url2", jackpot: "$2" },
+    {
+      id: "1",
+      name: "Game 1",
+      logoUrl: "url1",
+      jackpot: "$1",
+      mainMax: null,
+      mainCount: null,
+      suppCount: null,
+      suppMax: null,
+      powerballMax: null,
+    },
+    {
+      id: "2",
+      name: "Game 2",
+      logoUrl: "url2",
+      jackpot: "$2",
+      mainMax: null,
+      mainCount: null,
+      suppCount: null,
+      suppMax: null,
+      powerballMax: null,
+    },
   ];
 
   test("renders games and triggers selection", () => {

--- a/app/__tests__/GameOptions.test.tsx
+++ b/app/__tests__/GameOptions.test.tsx
@@ -31,6 +31,11 @@ jest.mock("expo-router", () => {
 });
 import { pushMock } from "expo-router";
 
+declare module "expo-router" {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pushMock: jest.Mock<any, any>;
+}
+
 jest.mock("../../lib/generator");
 jest.mock("../../lib/gamesApi");
 


### PR DESCRIPTION
## Summary
- ensure game tests use full `Game` objects
- make expo-router mock type-safe for test
- refine draw parsing types

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686000a972c4832fb494ef1eccfb9f09