### PR TITLE
Update Supabase env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-SUPABASE_URL=https://your-supabase-url.supabase.co
-SUPABASE_ANON_KEY=your-anon-key
+EXPO_PUBLIC_SUPABASE_URL=https://your-supabase-url.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/Docs/supabase-access.md
+++ b/Docs/supabase-access.md
@@ -6,8 +6,8 @@ environment variable when running `yarn sync-draws` or other node
 scripts.
 
 ```
-SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_ANON_KEY=anon-key
+EXPO_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=anon-key
 SUPABASE_SERVICE_ROLE_KEY=service-role-key
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ For deeper detail see [`Docs/Phase_0.md`](Docs/Phase_0.md) and [`Docs/WORKFLOW.m
    yarn test               # runs Jest smoke suite
    ```
 
-2. **Environment** – duplicate `.env.example` as `.env` (the file is gitignored) and add your Supabase keys and Slack webhooks.
+2. **Environment** – duplicate `.env.example` as `.env` (the file is gitignored) and add your Supabase keys (`EXPO_PUBLIC_SUPABASE_URL` and `EXPO_PUBLIC_SUPABASE_ANON_KEY`) along with any Slack webhooks.
 3. **Database** – run `/supabase/init.sql` or `supabase db reset` then `supabase start`.
 4. **Create Indexes** – `node lib/createIndexes.ts` prints SQL. Execute it via the Supabase SQL editor.
 5. **Sync Draw History** – `yarn sync-draws` fetches the latest results for all games.

--- a/app.config.ts
+++ b/app.config.ts
@@ -9,7 +9,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   version: config.version!,
   sdkVersion: config.sdkVersion!,
   extra: {
-    SUPABASE_URL: process.env.SUPABASE_URL!,
-    SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY!,
+    EXPO_PUBLIC_SUPABASE_URL: process.env.EXPO_PUBLIC_SUPABASE_URL!,
+    EXPO_PUBLIC_SUPABASE_ANON_KEY: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY!,
   },
 });

--- a/app/__tests__/DrawsScreen.test.tsx
+++ b/app/__tests__/DrawsScreen.test.tsx
@@ -11,8 +11,8 @@ jest.mock("expo-constants", () => ({
   default: {
     expoConfig: {
       extra: {
-        SUPABASE_URL: "https://test.supabase",
-        SUPABASE_ANON_KEY: "anon-test-key",
+        EXPO_PUBLIC_SUPABASE_URL: "https://test.supabase",
+        EXPO_PUBLIC_SUPABASE_ANON_KEY: "anon-test-key",
       },
     },
   },

--- a/app/__tests__/GameOptions.test.tsx
+++ b/app/__tests__/GameOptions.test.tsx
@@ -13,8 +13,8 @@ jest.mock("expo-constants", () => ({
   default: {
     expoConfig: {
       extra: {
-        SUPABASE_URL: "https://test.supabase",
-        SUPABASE_ANON_KEY: "anon-test-key",
+        EXPO_PUBLIC_SUPABASE_URL: "https://test.supabase",
+        EXPO_PUBLIC_SUPABASE_ANON_KEY: "anon-test-key",
       },
     },
   },

--- a/app/__tests__/Index.test.tsx
+++ b/app/__tests__/Index.test.tsx
@@ -3,8 +3,8 @@ jest.mock("expo-constants", () => ({
   default: {
     expoConfig: {
       extra: {
-        SUPABASE_URL: "https://test.supabase",
-        SUPABASE_ANON_KEY: "anon-test-key",
+        EXPO_PUBLIC_SUPABASE_URL: "https://test.supabase",
+        EXPO_PUBLIC_SUPABASE_ANON_KEY: "anon-test-key",
       },
     },
   },

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -3,13 +3,17 @@ import "react-native-url-polyfill/auto";
 import { createClient } from "@supabase/supabase-js";
 import Constants from "expo-constants";
 
-const { SUPABASE_URL, SUPABASE_ANON_KEY } = Constants.expoConfig!.extra as {
-  SUPABASE_URL: string;
-  SUPABASE_ANON_KEY: string;
+const { EXPO_PUBLIC_SUPABASE_URL, EXPO_PUBLIC_SUPABASE_ANON_KEY } = Constants
+  .expoConfig!.extra as {
+  EXPO_PUBLIC_SUPABASE_URL: string;
+  EXPO_PUBLIC_SUPABASE_ANON_KEY: string;
 };
 
-if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+if (!EXPO_PUBLIC_SUPABASE_URL || !EXPO_PUBLIC_SUPABASE_ANON_KEY) {
   throw new Error("Supabase URL or anon key not provided");
 }
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+export const supabase = createClient(
+  EXPO_PUBLIC_SUPABASE_URL,
+  EXPO_PUBLIC_SUPABASE_ANON_KEY,
+);

--- a/lib/syncDraws.ts
+++ b/lib/syncDraws.ts
@@ -6,8 +6,12 @@ import fetch from "cross-fetch";
 dotenv.config();
 
 // 2) Read and validate env vars
-const SUPABASE_URL: string = process.env.SUPABASE_URL ?? "";
-const SUPABASE_ANON_KEY: string = process.env.SUPABASE_ANON_KEY ?? "";
+const SUPABASE_URL: string =
+  process.env.SUPABASE_URL ?? process.env.EXPO_PUBLIC_SUPABASE_URL ?? "";
+const SUPABASE_ANON_KEY: string =
+  process.env.SUPABASE_ANON_KEY ??
+  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ??
+  "";
 const SUPABASE_SERVICE_ROLE_KEY: string =
   process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
 const supabaseKey: string = SUPABASE_SERVICE_ROLE_KEY || SUPABASE_ANON_KEY;

--- a/lib/syncHotCold.ts
+++ b/lib/syncHotCold.ts
@@ -7,10 +7,13 @@ dotenv.config();
 let supabase: SupabaseClient;
 
 function initSupabase(): void {
-  const SUPABASE_URL = process.env.SUPABASE_URL;
+  const SUPABASE_URL =
+    process.env.SUPABASE_URL ?? process.env.EXPO_PUBLIC_SUPABASE_URL;
   // Use the service role key for backend sync to bypass RLS
   const SUPABASE_KEY =
-    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_ANON_KEY;
+    process.env.SUPABASE_SERVICE_ROLE_KEY ??
+    process.env.SUPABASE_ANON_KEY ??
+    process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
   if (!SUPABASE_URL || !SUPABASE_KEY) {
     throw new Error("Supabase credentials are missing");
   }


### PR DESCRIPTION
## Summary
- change Supabase env variable names to `EXPO_PUBLIC_SUPABASE_*`
- read new names in expo config and Supabase client
- fallback to the new names in sync scripts
- update tests to mock new keys
- document the variable name change

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6860716450bc832fad4b7d45ed301b80