### PR TITLE
Add Supabase env fallback and tests

### DIFF
--- a/lib/__tests__/supabase.test.ts
+++ b/lib/__tests__/supabase.test.ts
@@ -1,0 +1,27 @@
+// Ensure each test gets a fresh module instance
+beforeEach(() => {
+  jest.resetModules();
+});
+
+test("falls back to env vars when expoConfig is null", () => {
+  process.env.EXPO_PUBLIC_SUPABASE_URL = "https://env.supabase";
+  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY = "env-anon-key";
+
+  jest.doMock("expo-constants", () => ({
+    __esModule: true,
+    default: { expoConfig: null },
+  }));
+
+  const createClient = jest.fn(() => ({ from: jest.fn() }));
+  jest.doMock("@supabase/supabase-js", () => ({ createClient }));
+
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("../supabase");
+  });
+
+  expect(createClient).toHaveBeenCalledWith(
+    "https://env.supabase",
+    "env-anon-key",
+  );
+});

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -3,14 +3,16 @@ import "react-native-url-polyfill/auto";
 import { createClient } from "@supabase/supabase-js";
 import Constants from "expo-constants";
 
-const { EXPO_PUBLIC_SUPABASE_URL, EXPO_PUBLIC_SUPABASE_ANON_KEY } = Constants
-  .expoConfig!.extra as {
-  EXPO_PUBLIC_SUPABASE_URL: string;
-  EXPO_PUBLIC_SUPABASE_ANON_KEY: string;
-};
+// Safely read Supabase credentials from app config or environment variables
+const extra = Constants.expoConfig?.extra ?? {};
+const EXPO_PUBLIC_SUPABASE_URL =
+  extra.EXPO_PUBLIC_SUPABASE_URL || process.env.EXPO_PUBLIC_SUPABASE_URL;
+const EXPO_PUBLIC_SUPABASE_ANON_KEY =
+  extra.EXPO_PUBLIC_SUPABASE_ANON_KEY ||
+  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
 if (!EXPO_PUBLIC_SUPABASE_URL || !EXPO_PUBLIC_SUPABASE_ANON_KEY) {
-  throw new Error("Supabase URL or anon key not provided");
+  throw new Error("Supabase credentials missing");
 }
 
 export const supabase = createClient(


### PR DESCRIPTION
## Summary
- support reading Supabase credentials from app config or environment variables
- mock environment variables in a new test

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6860908e6360832fb16989059e790211