### PR TITLE
Remove color blindness toggle

### DIFF
--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -11,7 +11,7 @@ import { useTheme } from "../lib/theme";
 import { useRouter } from "expo-router";
 
 export default function SettingsScreen() {
-  const { tokens, scheme, toggleScheme, isCvd, toggleCvd } = useTheme();
+  const { tokens, scheme, toggleScheme } = useTheme();
   const router = useRouter();
   const styles = StyleSheet.create({
     card: {
@@ -93,8 +93,6 @@ export default function SettingsScreen() {
           value={scheme === "dark"}
           onToggle={toggleScheme}
         />
-        <Separator />
-        <Row label="Colour-Blind Mode" value={isCvd} onToggle={toggleCvd} />
       </View>
 
       {/* --- Notifications Group (Placeholder) --- */}

--- a/app/tokens.json
+++ b/app/tokens.json
@@ -2,27 +2,19 @@
   "color": {
     "brand": {
       "primary": {
-        "value": "#0C244B",
-        "description": "Deep navy – trust & stability",
+        "value": "#005FA3",
+        "description": "CVD‑safe blue — AA 6.63 : 1 vs white",
         "dark": {
           "value": "#4B83E6",
           "description": "Light-blue primary for dark theme — AA 5.07 : 1 vs #121212"
-        },
-        "cvd": {
-          "value": "#005FA3",
-          "description": "CVD‑safe blue — AA 6.63 : 1 vs white"
         }
       },
       "accent": {
-        "value": "#F5A623",
-        "description": "Gold/orange – action highlight",
+        "value": "#006F5F",
+        "description": "CVD‑safe teal accent — AA 6.10 : 1 vs white",
         "dark": {
           "value": "#FDBB46",
           "description": "Bright gold accent for dark theme — AA 11.04 : 1 vs #121212"
-        },
-        "cvd": {
-          "value": "#006F5F",
-          "description": "CVD‑safe teal accent — AA 6.10 : 1 vs white"
         }
       }
     },

--- a/design/wireframes/Setting screen.md
+++ b/design/wireframes/Setting screen.md
@@ -5,8 +5,6 @@
 ▸ Display Settings
 ┌──────────────────────────────────────────┐
 │ Dark Mode ⬤◯ │ ToggleScheme (ThemeSwitch.tsx)
-├──────────────────────────────────────────┤
-│ Colour-Blind Mode ⬤◯ │ toggleCvd (SettingsRow.tsx)
 └──────────────────────────────────────────┘
 
 ▸ Notifications


### PR DESCRIPTION
## Summary
- drop colour-blind mode toggle from Theme context and settings UI
- set brand colours to the previous CVD-safe variants
- update wireframes to match

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6860a7d9eaa4832fa35d00bafd3e0ac9