### PR TITLE
Handle game draw cutoff

### DIFF
--- a/app/__tests__/DrawsScreen.test.tsx
+++ b/app/__tests__/DrawsScreen.test.tsx
@@ -56,6 +56,7 @@ describe("DrawsScreen", () => {
           suppCount: 1,
           suppMax: 40,
           powerballMax: 20,
+          fromDrawNumber: 1,
         },
       ],
     });

--- a/app/__tests__/GameCard.test.tsx
+++ b/app/__tests__/GameCard.test.tsx
@@ -24,6 +24,7 @@ describe("GameCard", () => {
     suppCount: null,
     suppMax: null,
     powerballMax: null,
+    fromDrawNumber: 1,
   };
 
   test("renders jackpot and handles press", () => {

--- a/app/__tests__/GameGrid.test.tsx
+++ b/app/__tests__/GameGrid.test.tsx
@@ -22,6 +22,7 @@ describe("GameGrid", () => {
       suppCount: null,
       suppMax: null,
       powerballMax: null,
+      fromDrawNumber: 1,
     },
     {
       id: "2",
@@ -33,6 +34,7 @@ describe("GameGrid", () => {
       suppCount: null,
       suppMax: null,
       powerballMax: null,
+      fromDrawNumber: 2,
     },
   ];
 

--- a/app/__tests__/GameOptions.test.tsx
+++ b/app/__tests__/GameOptions.test.tsx
@@ -65,6 +65,7 @@ describe("GameOptionsScreen", () => {
         suppCount: null,
         suppMax: null,
         powerballMax: 20,
+        fromDrawNumber: 100,
       },
     ]);
     const games = await fetchGames();
@@ -91,6 +92,7 @@ describe("GameOptionsScreen", () => {
         suppCount: 2,
         suppMax: 40,
         powerballMax: 20,
+        fromDrawNumber: 100,
       },
     ]);
     const games = await fetchGames();

--- a/app/__tests__/HotColdScreen.test.tsx
+++ b/app/__tests__/HotColdScreen.test.tsx
@@ -61,6 +61,7 @@ describe("HotColdScreen", () => {
           suppCount: null,
           suppMax: null,
           powerballMax: null,
+          fromDrawNumber: 1,
         },
       ],
     });

--- a/lib/__tests__/gamesApi.test.ts
+++ b/lib/__tests__/gamesApi.test.ts
@@ -35,6 +35,7 @@ describe("fetchGames", () => {
           supp_count: null,
           supp_max: null,
           powerball_max: 20,
+          from_draw_number: 100,
         },
       ],
       error: null,
@@ -59,11 +60,12 @@ describe("fetchGames", () => {
         suppCount: null,
         suppMax: null,
         powerballMax: 20,
+        fromDrawNumber: 100,
       },
     ]);
     expect(fromMock).toHaveBeenCalledWith("games");
     expect(selectMock).toHaveBeenCalledWith(
-      "id, name, logo_url, jackpot, main_max, main_count, supp_count, supp_max, powerball_max",
+      "id, name, logo_url, jackpot, main_max, main_count, supp_count, supp_max, powerball_max, from_draw_number",
     );
   });
 
@@ -80,6 +82,7 @@ describe("fetchGames", () => {
           supp_count: 2,
           supp_max: 47,
           powerball_max: 3,
+          from_draw_number: 200,
         },
       ],
       error: null,
@@ -116,6 +119,7 @@ describe("fetchGames", () => {
           supp_count: 2,
           supp_max: 40,
           powerball_max: null,
+          from_draw_number: 300,
         },
       ],
       error: null,

--- a/lib/__tests__/syncHotCold.test.ts
+++ b/lib/__tests__/syncHotCold.test.ts
@@ -17,6 +17,7 @@ describe("computeHotCold", () => {
         main_max: 5,
         supp_max: 10,
         powerball_max: 10,
+        from_draw_number: 1,
       },
       40,
     );

--- a/lib/gamesApi.ts
+++ b/lib/gamesApi.ts
@@ -22,6 +22,7 @@ export interface Game {
   suppCount: number | null;
   suppMax: number | null;
   powerballMax: number | null;
+  fromDrawNumber: number;
 }
 
 export interface GameRow {
@@ -34,6 +35,7 @@ export interface GameRow {
   supp_count: number | null;
   supp_max: number | null;
   powerball_max: number | null;
+  from_draw_number: number;
 }
 
 /** Collapse any “//” in the pathname (preserving “https://”) */
@@ -53,7 +55,7 @@ export async function fetchGames(force = false): Promise<Game[]> {
   const { data: rows, error } = await supabase
     .from("games")
     .select(
-      "id, name, logo_url, jackpot, main_max, main_count, supp_count, supp_max, powerball_max",
+      "id, name, logo_url, jackpot, main_max, main_count, supp_count, supp_max, powerball_max, from_draw_number",
     );
 
   if (error) {
@@ -89,6 +91,7 @@ export async function fetchGames(force = false): Promise<Game[]> {
       suppCount: row.supp_count ?? null,
       suppMax: row.supp_max ?? null,
       powerballMax: row.powerball_max ?? null,
+      fromDrawNumber: row.from_draw_number,
     };
   });
 

--- a/lib/syncHotCold.ts
+++ b/lib/syncHotCold.ts
@@ -25,6 +25,7 @@ interface GameConfig {
   main_max: number;
   supp_max?: number | null;
   powerball_max?: number | null;
+  from_draw_number: number;
 }
 
 interface DrawRow {
@@ -102,6 +103,7 @@ async function updateGameHotCold(game: GameConfig): Promise<void> {
       .from("draws")
       .select("draw_results(number, ball_types(name))")
       .eq("game_id", game.id)
+      .gte("draw_number", game.from_draw_number)
       .range(from, to);
 
     if (error) {
@@ -155,7 +157,7 @@ async function updateGameHotCold(game: GameConfig): Promise<void> {
 export async function syncAllHotCold(): Promise<void> {
   const { data, error } = await supabase
     .from("games")
-    .select("id, main_max, supp_max, powerball_max");
+    .select("id, main_max, supp_max, powerball_max, from_draw_number");
 
   if (error) {
     throw new Error(


### PR DESCRIPTION
## Summary
- include `fromDrawNumber` for each game in `fetchGames`
- filter draws by `from_draw_number` in `syncHotCold`
- update tests for new field

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6860d4b7434c832fafc881f2a31b5bed