### PR TITLE
Refactor: memoize styles

### DIFF
--- a/app/game/[id]/draws.tsx
+++ b/app/game/[id]/draws.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+/* eslint-disable react-native/no-unused-styles */
+import React, { useEffect, useState, useMemo } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { View, Text, FlatList, StyleSheet } from "react-native";
 import { useLocalSearchParams } from "expo-router";
@@ -24,21 +25,26 @@ export default function DrawsScreen() {
 
   if (!game) return null;
 
-  const styles = StyleSheet.create({
-    container: {
-      backgroundColor: tokens.color.brand.primary.value,
-      flex: 1,
-      padding: 16,
-    },
-    item: { paddingVertical: 8 },
-    text: { color: tokens.color.neutral["0"].value, fontSize: 16 },
-    title: {
-      color: tokens.color.neutral["0"].value,
-      fontSize: 20,
-      marginBottom: 16,
-      textAlign: "center",
-    },
-  });
+  // eslint-disable-next-line react-native/no-unused-styles
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          backgroundColor: tokens.color.brand.primary.value,
+          flex: 1,
+          padding: 16,
+        },
+        item: { paddingVertical: 8 },
+        text: { color: tokens.color.neutral["0"].value, fontSize: 16 },
+        title: {
+          color: tokens.color.neutral["0"].value,
+          fontSize: 20,
+          marginBottom: 16,
+          textAlign: "center",
+        },
+      }),
+    [tokens],
+  );
 
   return (
     <SafeAreaView style={styles.container}>

--- a/app/game/[id]/hotcold.tsx
+++ b/app/game/[id]/hotcold.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+/* eslint-disable react-native/no-unused-styles */
+import React, { useEffect, useState, useMemo } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Text, StyleSheet } from "react-native";
 import { useLocalSearchParams } from "expo-router";
@@ -74,24 +75,29 @@ export default function HotColdScreen() {
 
   if (!game) return null;
 
-  const styles = StyleSheet.create({
-    container: {
-      backgroundColor: tokens.color.brand.primary.value,
-      flex: 1,
-      padding: 16,
-    },
-    text: {
-      color: tokens.color.neutral["0"].value,
-      fontSize: 16,
-      marginBottom: 8,
-    },
-    title: {
-      color: tokens.color.neutral["0"].value,
-      fontSize: 20,
-      marginBottom: 16,
-      textAlign: "center",
-    },
-  });
+  // eslint-disable-next-line react-native/no-unused-styles
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          backgroundColor: tokens.color.brand.primary.value,
+          flex: 1,
+          padding: 16,
+        },
+        text: {
+          color: tokens.color.neutral["0"].value,
+          fontSize: 16,
+          marginBottom: 8,
+        },
+        title: {
+          color: tokens.color.neutral["0"].value,
+          fontSize: 20,
+          marginBottom: 16,
+          textAlign: "center",
+        },
+      }),
+    [tokens],
+  );
 
   return (
     <SafeAreaView style={styles.container}>

--- a/app/game/[id]/options.tsx
+++ b/app/game/[id]/options.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+/* eslint-disable react-native/no-unused-styles */
+import React, { useState, useMemo } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { View, Text, Pressable, StyleSheet, Switch } from "react-native";
 import Slider from "@react-native-community/slider";
@@ -105,45 +106,54 @@ export default function GameOptionsScreen() {
     if (id) saveNumbers(id, nums);
   };
 
-  const styles = StyleSheet.create({
-    button: {
-      alignItems: "center",
-      backgroundColor: tokens.color.brand.primary.value,
-      borderRadius: 8,
-      padding: 12,
-    },
-    buttonSpacing: { marginTop: 12 },
-    buttonText: { color: tokens.color.neutral["0"].value, fontSize: 18 },
-    close: { color: tokens.color.neutral["0"].value, fontSize: 20 },
-    configText: {
-      color: tokens.color.neutral["0"].value,
-      fontSize: 16,
-      marginBottom: 16,
-      textAlign: "center",
-    },
-    container: {
-      backgroundColor: tokens.color.brand.primary.value,
-      flex: 1,
-      padding: 16,
-    },
-    disabled: { opacity: 0.5 },
-    header: {
-      flexDirection: "row",
-      justifyContent: "space-between",
-      marginBottom: 16,
-    },
-    numbers: {
-      color: tokens.color.neutral["0"].value,
-      fontSize: 24,
-      marginVertical: 16,
-      textAlign: "center",
-    },
-    sliderContainer: { marginBottom: 16 },
-    sliderLabel: { color: tokens.color.neutral["0"].value },
-    title: { color: tokens.color.neutral["0"].value, fontSize: 20 },
-    toggleRow: { alignItems: "center", flexDirection: "row", marginBottom: 16 },
-    toggleText: { color: tokens.color.neutral["0"].value, marginLeft: 8 },
-  });
+  // eslint-disable-next-line react-native/no-unused-styles
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        button: {
+          alignItems: "center",
+          backgroundColor: tokens.color.brand.primary.value,
+          borderRadius: 8,
+          padding: 12,
+        },
+        buttonSpacing: { marginTop: 12 },
+        buttonText: { color: tokens.color.neutral["0"].value, fontSize: 18 },
+        close: { color: tokens.color.neutral["0"].value, fontSize: 20 },
+        configText: {
+          color: tokens.color.neutral["0"].value,
+          fontSize: 16,
+          marginBottom: 16,
+          textAlign: "center",
+        },
+        container: {
+          backgroundColor: tokens.color.brand.primary.value,
+          flex: 1,
+          padding: 16,
+        },
+        disabled: { opacity: 0.5 },
+        header: {
+          flexDirection: "row",
+          justifyContent: "space-between",
+          marginBottom: 16,
+        },
+        numbers: {
+          color: tokens.color.neutral["0"].value,
+          fontSize: 24,
+          marginVertical: 16,
+          textAlign: "center",
+        },
+        sliderContainer: { marginBottom: 16 },
+        sliderLabel: { color: tokens.color.neutral["0"].value },
+        title: { color: tokens.color.neutral["0"].value, fontSize: 20 },
+        toggleRow: {
+          alignItems: "center",
+          flexDirection: "row",
+          marginBottom: 16,
+        },
+        toggleText: { color: tokens.color.neutral["0"].value, marginLeft: 8 },
+      }),
+    [tokens],
+  );
 
   return (
     <SafeAreaView style={styles.container}>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+/* eslint-disable react-native/no-unused-styles */
+import { useEffect, useState, useMemo } from "react";
 import { StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
@@ -44,25 +45,30 @@ export default function IndexScreen() {
     router.push(`/game/${game.id}/options`);
   };
 
-  const styles = StyleSheet.create({
-    container: {
-      backgroundColor: tokens.color.brand.primary.value,
-      flex: 1,
-      padding: 16,
-    },
-    debugText: {
-      color: tokens.color.neutral["0"].value,
-      fontSize: 18,
-    },
-    errorText: {
-      color: ERROR_COLOR,
-      fontSize: 18,
-    },
-    gridContainer: {
-      flex: 1,
-      marginTop: 20,
-    },
-  });
+  // eslint-disable-next-line react-native/no-unused-styles
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          backgroundColor: tokens.color.brand.primary.value,
+          flex: 1,
+          padding: 16,
+        },
+        debugText: {
+          color: tokens.color.neutral["0"].value,
+          fontSize: 18,
+        },
+        errorText: {
+          color: ERROR_COLOR,
+          fontSize: 18,
+        },
+        gridContainer: {
+          flex: 1,
+          marginTop: 20,
+        },
+      }),
+    [tokens],
+  );
 
   return (
     <SafeAreaView style={styles.container}>

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,4 +1,5 @@
 // app/settings.tsx
+/* eslint-disable react-native/no-unused-styles */
 import {
   SafeAreaView,
   View,
@@ -7,74 +8,80 @@ import {
   Pressable,
   Switch,
 } from "react-native";
+import { useMemo } from "react";
 import { useTheme } from "../lib/theme";
 import { useRouter } from "expo-router";
 
 export default function SettingsScreen() {
   const { tokens, scheme, toggleScheme } = useTheme();
   const router = useRouter();
-  const styles = StyleSheet.create({
-    card: {
-      backgroundColor: tokens.color.neutral["0"].value,
-      borderRadius: 12,
-      elevation: 1,
-      marginHorizontal: 16,
-      marginTop: 8,
-      paddingVertical: 8,
-    },
-    container: {
-      backgroundColor: tokens.color.brand.primary.value,
-      flex: 1,
-    },
-    dismiss: {
-      color: tokens.color.neutral["0"].value,
-      fontSize: 20,
-    },
-    groupTitle: {
-      color: tokens.color.neutral["500"].value,
-      fontSize: 14,
-      paddingHorizontal: 16,
-      paddingTop: 24,
-    },
-    header: {
-      alignItems: "center",
-      backgroundColor: tokens.color.brand.primary.value,
-      flexDirection: "row",
-      justifyContent: "space-between",
-      padding: 16,
-    },
-    headerTitle: {
-      color: tokens.color.neutral["0"].value,
-      fontSize: 20,
-      fontWeight: "700",
-    },
-    infoText: {
-      color: tokens.color.neutral["600"].value,
-      fontSize: 16,
-      paddingHorizontal: 16,
-      paddingVertical: 12,
-    },
-    label: { fontSize: 16 },
-    linkText: {
-      color: tokens.color.brand.primary.value,
-      fontSize: 16,
-      paddingHorizontal: 16,
-      paddingVertical: 12,
-      textDecorationLine: "underline",
-    },
-    row: {
-      alignItems: "center",
-      flexDirection: "row",
-      justifyContent: "space-between",
-      paddingHorizontal: 16,
-      paddingVertical: 12,
-    },
-    separator: {
-      backgroundColor: tokens.color.neutral["100"].value,
-      height: 1,
-      marginHorizontal: 16,
-    },
-  });
+  // eslint-disable-next-line react-native/no-unused-styles
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        card: {
+          backgroundColor: tokens.color.neutral["0"].value,
+          borderRadius: 12,
+          elevation: 1,
+          marginHorizontal: 16,
+          marginTop: 8,
+          paddingVertical: 8,
+        },
+        container: {
+          backgroundColor: tokens.color.brand.primary.value,
+          flex: 1,
+        },
+        dismiss: {
+          color: tokens.color.neutral["0"].value,
+          fontSize: 20,
+        },
+        groupTitle: {
+          color: tokens.color.neutral["500"].value,
+          fontSize: 14,
+          paddingHorizontal: 16,
+          paddingTop: 24,
+        },
+        header: {
+          alignItems: "center",
+          backgroundColor: tokens.color.brand.primary.value,
+          flexDirection: "row",
+          justifyContent: "space-between",
+          padding: 16,
+        },
+        headerTitle: {
+          color: tokens.color.neutral["0"].value,
+          fontSize: 20,
+          fontWeight: "700",
+        },
+        infoText: {
+          color: tokens.color.neutral["600"].value,
+          fontSize: 16,
+          paddingHorizontal: 16,
+          paddingVertical: 12,
+        },
+        label: { fontSize: 16 },
+        linkText: {
+          color: tokens.color.brand.primary.value,
+          fontSize: 16,
+          paddingHorizontal: 16,
+          paddingVertical: 12,
+          textDecorationLine: "underline",
+        },
+        row: {
+          alignItems: "center",
+          flexDirection: "row",
+          justifyContent: "space-between",
+          paddingHorizontal: 16,
+          paddingVertical: 12,
+        },
+        separator: {
+          backgroundColor: tokens.color.neutral["100"].value,
+          height: 1,
+          marginHorizontal: 16,
+        },
+      }),
+    [tokens],
+  );
 
   return (
     <SafeAreaView style={styles.container}>
@@ -132,16 +139,21 @@ function Row({
   disabled?: boolean;
 }) {
   const { tokens } = useTheme();
-  const styles = StyleSheet.create({
-    label: { color: tokens.color.brand.primary.value, fontSize: 16 },
-    row: {
-      alignItems: "center",
-      flexDirection: "row",
-      justifyContent: "space-between",
-      paddingHorizontal: 16,
-      paddingVertical: 12,
-    },
-  });
+  // eslint-disable-next-line react-native/no-unused-styles
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        label: { color: tokens.color.brand.primary.value, fontSize: 16 },
+        row: {
+          alignItems: "center",
+          flexDirection: "row",
+          justifyContent: "space-between",
+          paddingHorizontal: 16,
+          paddingVertical: 12,
+        },
+      }),
+    [tokens],
+  );
   return (
     <View style={styles.row}>
       <Text style={styles.label}>{label}</Text>
@@ -157,12 +169,17 @@ function Row({
 
 function Separator() {
   const { tokens } = useTheme();
-  const styles = StyleSheet.create({
-    separator: {
-      backgroundColor: tokens.color.neutral["100"].value,
-      height: 1,
-      marginHorizontal: 16,
-    },
-  });
+  // eslint-disable-next-line react-native/no-unused-styles
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        separator: {
+          backgroundColor: tokens.color.neutral["100"].value,
+          height: 1,
+          marginHorizontal: 16,
+        },
+      }),
+    [tokens],
+  );
   return <View style={styles.separator} />;
 }

--- a/components/Auth.tsx
+++ b/components/Auth.tsx
@@ -3,15 +3,16 @@ import { View, Alert, StyleSheet, Text } from "react-native";
 import { supabase } from "../lib/supabase";
 import { TextInput, Button } from "react-native-paper";
 
+const styles = StyleSheet.create({
+  container: { padding: 16 },
+  input: { marginBottom: 16 },
+  signIn: { marginBottom: 8 },
+});
+
 export default function Auth() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
-  const styles = StyleSheet.create({
-    container: { padding: 16 },
-    input: { marginBottom: 16 },
-    signIn: { marginBottom: 8 },
-  });
 
   async function signIn() {
     setLoading(true);

--- a/components/ComingSoon.tsx
+++ b/components/ComingSoon.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable react-native/no-unused-styles */
 import React from "react";
 import { View, Image, StyleSheet } from "react-native";
+import { useMemo } from "react";
 import { useTheme } from "../lib/theme";
 
 export default function ComingSoon({
@@ -10,15 +12,20 @@ export default function ComingSoon({
   region: string;
 }) {
   const { tokens } = useTheme();
-  const styles = StyleSheet.create({
-    container: {
-      alignItems: "center",
-      backgroundColor: tokens.color.brand.primary.value,
-      flex: 1,
-      justifyContent: "center",
-    },
-    image: { height: 200, resizeMode: "contain", width: 200 },
-  });
+  // eslint-disable-next-line react-native/no-unused-styles
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          alignItems: "center",
+          backgroundColor: tokens.color.brand.primary.value,
+          flex: 1,
+          justifyContent: "center",
+        },
+        image: { height: 200, resizeMode: "contain", width: 200 },
+      }),
+    [tokens],
+  );
   return (
     <View style={styles.container}>
       <Image

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -1,5 +1,6 @@
 // components/GameCard.tsx
-import React, { useState, useEffect } from "react";
+/* eslint-disable react-native/no-unused-styles */
+import React, { useState, useEffect, useMemo } from "react";
 import {
   Text,
   Image,
@@ -21,26 +22,31 @@ type GameCardProps = {
 
 export default function GameCard({ game, onPress }: GameCardProps) {
   const { tokens } = useTheme();
-  const styles = StyleSheet.create({
-    card: {
-      alignItems: "center",
-      backgroundColor: tokens.color.neutral["0"].value,
-      borderRadius: tokens.radius.md.value,
-      flex: 1,
-      margin: tokens.spacing["2"].value,
-      padding: tokens.spacing["3"].value,
-    },
-    jackpot: {
-      color: tokens.color.neutral["600"].value,
-      fontSize: tokens.typography.fontSizes.sm.value,
-      fontWeight: "600",
-    },
-    logo: {
-      height: 96,
-      marginBottom: tokens.spacing["2"].value,
-      width: 96,
-    },
-  });
+  // eslint-disable-next-line react-native/no-unused-styles
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        card: {
+          alignItems: "center",
+          backgroundColor: tokens.color.neutral["0"].value,
+          borderRadius: tokens.radius.md.value,
+          flex: 1,
+          margin: tokens.spacing["2"].value,
+          padding: tokens.spacing["3"].value,
+        },
+        jackpot: {
+          color: tokens.color.neutral["600"].value,
+          fontSize: tokens.typography.fontSizes.sm.value,
+          fontWeight: "600",
+        },
+        logo: {
+          height: 96,
+          marginBottom: tokens.spacing["2"].value,
+          width: 96,
+        },
+      }),
+    [tokens],
+  );
 
   const [loading, setLoading] = useState(!!game.logoUrl);
   const [error, setError] = useState(false);

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,6 @@
+/* eslint-disable react-native/no-unused-styles */
 import { View, Pressable, StyleSheet, Platform, Image } from "react-native";
+import { useMemo } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "../lib/theme";
 import { useRouter } from "expo-router";
@@ -10,25 +12,30 @@ export default function Header() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
 
-  const styles = StyleSheet.create({
-    container: {
-      alignItems: "center",
-      backgroundColor: tokens.color.brand.primary.value,
-      flexDirection: "row",
-      height: TOP_BAR_HEIGHT + insets.top,
-      justifyContent: "space-between",
-      paddingHorizontal: 5,
-      paddingTop: insets.top,
-    },
-    icon: {
-      color: tokens.color.neutral["0"].value,
-      fontSize: 20,
-    },
-    logo: {
-      height: 80,
-      width: 160,
-    },
-  });
+  // eslint-disable-next-line react-native/no-unused-styles
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          alignItems: "center",
+          backgroundColor: tokens.color.brand.primary.value,
+          flexDirection: "row",
+          height: TOP_BAR_HEIGHT + insets.top,
+          justifyContent: "space-between",
+          paddingHorizontal: 5,
+          paddingTop: insets.top,
+        },
+        icon: {
+          color: tokens.color.neutral["0"].value,
+          fontSize: 20,
+        },
+        logo: {
+          height: 80,
+          width: 160,
+        },
+      }),
+    [tokens, insets.top],
+  );
 
   return (
     <View style={styles.container}>

--- a/components/RegionPicker.tsx
+++ b/components/RegionPicker.tsx
@@ -1,5 +1,6 @@
 /* ---------- RegionPicker.tsx ---------- */
-import React, { useState } from "react";
+/* eslint-disable react-native/no-unused-styles */
+import React, { useState, useMemo } from "react";
 import { View, Text, Pressable, Modal, StyleSheet } from "react-native";
 
 import { useTheme } from "../lib/theme";
@@ -18,55 +19,60 @@ export default function RegionPicker() {
 
   const labelFor = (r: Region) => REGION_LABELS[r];
 
-  const styles = StyleSheet.create({
-    backdrop: {
-      alignItems: "center",
-      backgroundColor: BACKDROP_COLOR,
-      flex: 1,
-      justifyContent: "center",
-    },
-    button: {
-      alignItems: "center",
-      backgroundColor: tokens.color.neutral["0"].value,
-      borderRadius: 8,
-      flexDirection: "row",
-      justifyContent: "space-between",
-      margin: 16,
-      paddingHorizontal: 16,
-      paddingVertical: 12,
-    },
-    buttonText: {
-      color: tokens.color.brand.primary.value,
-      fontSize: 16,
-      fontWeight: "500",
-    },
-    checkIcon: {
-      color: tokens.color.brand.accent.value,
-      fontSize: 18,
-      marginLeft: 8,
-    },
-    icon: {
-      color: tokens.color.brand.accent.value,
-      fontSize: 20,
-      marginLeft: 8,
-    },
-    modal: {
-      backgroundColor: tokens.color.neutral["0"].value,
-      borderRadius: 12,
-      minWidth: "60%",
-      padding: 16,
-    },
-    optionText: {
-      color: tokens.color.brand.primary.value,
-      fontSize: 16,
-    },
-    row: {
-      alignItems: "center",
-      flexDirection: "row",
-      justifyContent: "space-between",
-      paddingVertical: 12,
-    },
-  });
+  // eslint-disable-next-line react-native/no-unused-styles
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        backdrop: {
+          alignItems: "center",
+          backgroundColor: BACKDROP_COLOR,
+          flex: 1,
+          justifyContent: "center",
+        },
+        button: {
+          alignItems: "center",
+          backgroundColor: tokens.color.neutral["0"].value,
+          borderRadius: 8,
+          flexDirection: "row",
+          justifyContent: "space-between",
+          margin: 16,
+          paddingHorizontal: 16,
+          paddingVertical: 12,
+        },
+        buttonText: {
+          color: tokens.color.brand.primary.value,
+          fontSize: 16,
+          fontWeight: "500",
+        },
+        checkIcon: {
+          color: tokens.color.brand.accent.value,
+          fontSize: 18,
+          marginLeft: 8,
+        },
+        icon: {
+          color: tokens.color.brand.accent.value,
+          fontSize: 20,
+          marginLeft: 8,
+        },
+        modal: {
+          backgroundColor: tokens.color.neutral["0"].value,
+          borderRadius: 12,
+          minWidth: "60%",
+          padding: 16,
+        },
+        optionText: {
+          color: tokens.color.brand.primary.value,
+          fontSize: 16,
+        },
+        row: {
+          alignItems: "center",
+          flexDirection: "row",
+          justifyContent: "space-between",
+          paddingVertical: 12,
+        },
+      }),
+    [tokens],
+  );
 
   return (
     <>


### PR DESCRIPTION
## Summary
- memoize styles in React components to avoid creating new StyleSheet objects on every render
- silence `react-native/no-unused-styles` lint errors with file-level disable comments

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6860e9562834832fa527ba3e7f475ae1