### PR TITLE
Improve Supabase env error

### DIFF
--- a/lib/__tests__/supabase.test.ts
+++ b/lib/__tests__/supabase.test.ts
@@ -25,3 +25,20 @@ test("falls back to env vars when expoConfig is null", () => {
     "env-anon-key",
   );
 });
+
+test("throws helpful error when credentials are missing", () => {
+  delete process.env.EXPO_PUBLIC_SUPABASE_URL;
+  delete process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+
+  jest.doMock("expo-constants", () => ({
+    __esModule: true,
+    default: { expoConfig: null },
+  }));
+
+  expect(() => {
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require("../supabase");
+    });
+  }).toThrow(/EXPO_PUBLIC_SUPABASE_URL.*EXPO_PUBLIC_SUPABASE_ANON_KEY/);
+});

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -12,7 +12,15 @@ const EXPO_PUBLIC_SUPABASE_ANON_KEY =
   process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
 if (!EXPO_PUBLIC_SUPABASE_URL || !EXPO_PUBLIC_SUPABASE_ANON_KEY) {
-  throw new Error("Supabase credentials missing");
+  const missing = [];
+  if (!EXPO_PUBLIC_SUPABASE_URL) missing.push("EXPO_PUBLIC_SUPABASE_URL");
+  if (!EXPO_PUBLIC_SUPABASE_ANON_KEY)
+    missing.push("EXPO_PUBLIC_SUPABASE_ANON_KEY");
+  throw new Error(
+    `Supabase credentials missing. Please set ${missing.join(
+      " and ",
+    )} in your app config or environment variables.`,
+  );
 }
 
 export const supabase = createClient(


### PR DESCRIPTION
## Summary
- throw a more descriptive error when Supabase env vars are missing
- test error handling for misconfigured environment variables

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6860e98aded8832f92f5ef7913297177