### PR TITLE
Adjust game grid layout

### DIFF
--- a/components/GameGrid.tsx
+++ b/components/GameGrid.tsx
@@ -13,7 +13,7 @@ export default function GameGrid({ games, onSelectGame }: GameGridProps) {
     <FlatList<Game>
       data={games}
       keyExtractor={(item: Game) => item.id}
-      numColumns={2}
+      numColumns={1}
       contentContainerStyle={styles.list}
       renderItem={({ item }: { item: Game }) => (
         <GameCard game={item} onPress={() => onSelectGame(item)} />


### PR DESCRIPTION
## Summary
- switch game grid to a single column to reduce clutter on the home screen

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686115f26904832fb22da5ffb48e5b09