### PR TITLE
Fix GameCard last draw details

### DIFF
--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -148,6 +148,12 @@ export default function GameCard({ game, onPress }: GameCardProps) {
           <Text style={styles.lastDrawLabel}>Last Draw</Text>
           <Text style={styles.lastDraw}>
             #{lastDraw.draw_number}: {lastDraw.winning_numbers.join(" - ")}
+            {lastDraw.supplementary_numbers?.length
+              ? ` - Supp: ${lastDraw.supplementary_numbers.join(" - ")}`
+              : ""}
+            {lastDraw.powerball !== null && lastDraw.powerball !== undefined
+              ? ` - Powerball: ${lastDraw.powerball}`
+              : ""}
           </Text>
         </>
       )}


### PR DESCRIPTION
## Summary
- show supplementary numbers and Powerball on each game card

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68611e7347b8832f8858a9a89fd664cb