### PR TITLE
Fix last draw display on home screen

### DIFF
--- a/app/__tests__/GameCard.test.tsx
+++ b/app/__tests__/GameCard.test.tsx
@@ -65,7 +65,7 @@ describe("GameCard", () => {
     expect(getByText("$1,000")).toBeTruthy();
     expect(getByText("Jackpot")).toBeTruthy();
     expect(getByText(/Next Draw/)).toBeTruthy();
-    await waitFor(() => expect(getByText(/Last Draw/)).toBeTruthy());
+    await waitFor(() => expect(getByText("Last Draw: #1")).toBeTruthy());
     fireEvent.press(getByRole("button"));
     expect(onPress).toHaveBeenCalled();
   });

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -145,16 +145,20 @@ export default function GameCard({ game, onPress }: GameCardProps) {
       )}
       {lastDraw && (
         <>
-          <Text style={styles.lastDrawLabel}>Last Draw</Text>
-          <Text style={styles.lastDraw}>
-            #{lastDraw.draw_number}: {lastDraw.winning_numbers.join(" - ")}
-            {lastDraw.supplementary_numbers?.length
-              ? ` - Supp: ${lastDraw.supplementary_numbers.join(" - ")}`
-              : ""}
-            {lastDraw.powerball !== null && lastDraw.powerball !== undefined
-              ? ` - Powerball: ${lastDraw.powerball}`
-              : ""}
+          <Text style={styles.lastDrawLabel}>
+            Last Draw: #{lastDraw.draw_number}
           </Text>
+          <Text style={styles.lastDraw}>
+            Winning Numbers: {lastDraw.winning_numbers.join(" - ")}
+          </Text>
+          {lastDraw.supplementary_numbers?.length ? (
+            <Text style={styles.lastDraw}>
+              Supps: {lastDraw.supplementary_numbers.join(" - ")}
+            </Text>
+          ) : null}
+          {lastDraw.powerball !== null && lastDraw.powerball !== undefined ? (
+            <Text style={styles.lastDraw}>Powerball: {lastDraw.powerball}</Text>
+          ) : null}
         </>
       )}
     </Pressable>


### PR DESCRIPTION
## Summary
- show last draw number inline with label
- show winning numbers and supps/powerball on separate lines
- update tests

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686125a4f7fc832fa3afa22351c32a8b