### PR TITLE
feat: improve game card draw layout

### DIFF
--- a/app/__tests__/GameCard.test.tsx
+++ b/app/__tests__/GameCard.test.tsx
@@ -66,6 +66,8 @@ describe("GameCard", () => {
     expect(getByText("Jackpot")).toBeTruthy();
     expect(getByText(/Next Draw/)).toBeTruthy();
     await waitFor(() => expect(getByText("Last Draw: #1")).toBeTruthy());
+    expect(getByText("Winning Numbers")).toBeTruthy();
+    expect(getByText("1 - 2 - 3")).toBeTruthy();
     fireEvent.press(getByRole("button"));
     expect(onPress).toHaveBeenCalled();
   });

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -148,16 +148,23 @@ export default function GameCard({ game, onPress }: GameCardProps) {
           <Text style={styles.lastDrawLabel}>
             Last Draw: #{lastDraw.draw_number}
           </Text>
+          <Text style={styles.lastDrawLabel}>Winning Numbers</Text>
           <Text style={styles.lastDraw}>
-            Winning Numbers: {lastDraw.winning_numbers.join(" - ")}
+            {lastDraw.winning_numbers.join(" - ")}
           </Text>
           {lastDraw.supplementary_numbers?.length ? (
-            <Text style={styles.lastDraw}>
-              Supps: {lastDraw.supplementary_numbers.join(" - ")}
-            </Text>
-          ) : null}
-          {lastDraw.powerball !== null && lastDraw.powerball !== undefined ? (
-            <Text style={styles.lastDraw}>Powerball: {lastDraw.powerball}</Text>
+            <>
+              <Text style={styles.lastDrawLabel}>Supps</Text>
+              <Text style={styles.lastDraw}>
+                {lastDraw.supplementary_numbers.join(" - ")}
+              </Text>
+            </>
+          ) : lastDraw.powerball !== null &&
+            lastDraw.powerball !== undefined ? (
+            <>
+              <Text style={styles.lastDrawLabel}>Powerball</Text>
+              <Text style={styles.lastDraw}>{lastDraw.powerball}</Text>
+            </>
           ) : null}
         </>
       )}


### PR DESCRIPTION
## Summary
- adjust layout for last draw info on GameCard
- update GameCard tests for new display

## Testing
- `yarn lint`
- `yarn format`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_686128b6cc68832f8cc19ee06902c809