### PR TITLE
Simplify game cards on home screen

### DIFF
--- a/app/__tests__/GameCard.test.tsx
+++ b/app/__tests__/GameCard.test.tsx
@@ -1,10 +1,9 @@
 import React from "react";
-import { render, fireEvent, waitFor } from "@testing-library/react-native";
+import { render, fireEvent } from "@testing-library/react-native";
 import { Image, ActivityIndicator } from "react-native";
 import { Provider as PaperProvider } from "react-native-paper";
 import { ThemeProvider } from "../../lib/theme";
 import GameCard from "../../components/GameCard";
-import { fetchRecentDraws } from "../../lib/gamesApi";
 
 jest.mock("expo-constants", () => ({
   __esModule: true,
@@ -17,10 +16,6 @@ jest.mock("expo-constants", () => ({
     },
   },
 }));
-
-jest.mock("../../lib/gamesApi");
-
-const fetchRecentDrawsMock = fetchRecentDraws as jest.Mock;
 
 jest.mock("../../assets/placeholder.png", () => 1);
 
@@ -45,16 +40,6 @@ describe("GameCard", () => {
     fromDrawNumber: 1,
   };
 
-  beforeEach(() => {
-    fetchRecentDrawsMock.mockResolvedValue([
-      {
-        draw_number: 1,
-        draw_date: "2024-01-01",
-        winning_numbers: [1, 2, 3],
-      },
-    ]);
-  });
-
   test("renders jackpot and handles press", async () => {
     const onPress = jest.fn();
     const { getByText, getByRole } = render(
@@ -63,11 +48,8 @@ describe("GameCard", () => {
     );
 
     expect(getByText("$1,000")).toBeTruthy();
-    expect(getByText("Jackpot")).toBeTruthy();
-    expect(getByText(/Next Draw/)).toBeTruthy();
-    await waitFor(() => expect(getByText("Last Draw: #1")).toBeTruthy());
-    expect(getByText("Winning Numbers")).toBeTruthy();
-    expect(getByText("1 - 2 - 3")).toBeTruthy();
+    const next = new Date(baseGame.nextDrawTime).toLocaleString();
+    expect(getByText(next)).toBeTruthy();
     fireEvent.press(getByRole("button"));
     expect(onPress).toHaveBeenCalled();
   });

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -1,6 +1,6 @@
 // components/GameCard.tsx
 /* eslint-disable react-native/no-unused-styles */
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import {
   Text,
   Image,
@@ -12,8 +12,7 @@ import {
   StyleProp,
 } from "react-native";
 import { useTheme } from "../lib/theme";
-import type { Game, DrawResult } from "../lib/gamesApi";
-import { fetchRecentDraws } from "../lib/gamesApi";
+import type { Game } from "../lib/gamesApi";
 import placeholder from "../assets/placeholder.png";
 
 type GameCardProps = {
@@ -40,38 +39,14 @@ export default function GameCard({ game, onPress }: GameCardProps) {
           fontSize: tokens.typography.fontSizes.lg.value,
           fontWeight: "700",
         },
-        jackpotLabel: {
-          color: tokens.color.neutral["500"].value,
-          fontSize: tokens.typography.fontSizes.xs.value,
-        },
-        lastDraw: {
-          color: tokens.color.neutral["600"].value,
-          fontSize: tokens.typography.fontSizes.sm.value,
-        },
-        lastDrawLabel: {
-          color: tokens.color.neutral["500"].value,
-          fontSize: tokens.typography.fontSizes.xs.value,
-          marginTop: tokens.spacing["2"].value,
-        },
         logo: {
           height: 96,
           marginBottom: tokens.spacing["3"].value,
           width: 96,
         },
-        name: {
-          color: tokens.color.brand.primary.value,
-          fontSize: tokens.typography.fontSizes.lg.value,
-          fontWeight: "700",
-          marginBottom: tokens.spacing["1"].value,
-        },
         nextDraw: {
           color: tokens.color.neutral["600"].value,
           fontSize: tokens.typography.fontSizes.sm.value,
-        },
-        nextDrawLabel: {
-          color: tokens.color.neutral["500"].value,
-          fontSize: tokens.typography.fontSizes.xs.value,
-          marginTop: tokens.spacing["2"].value,
         },
       }),
     [tokens],
@@ -79,23 +54,6 @@ export default function GameCard({ game, onPress }: GameCardProps) {
 
   const [loading, setLoading] = useState(!!game.logoUrl);
   const [error, setError] = useState(false);
-  const [lastDraw, setLastDraw] = useState<DrawResult | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const draws = await fetchRecentDraws(game.id);
-        if (!cancelled) setLastDraw(draws[0] ?? null);
-      } catch (err) {
-        console.error("GameCard fetch draws", err);
-      }
-    };
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, [game.id]);
 
   useEffect(() => {
     if (!game.logoUrl) {
@@ -132,41 +90,11 @@ export default function GameCard({ game, onPress }: GameCardProps) {
           }}
         />
       )}
-      <Text style={styles.name}>{game.name}</Text>
-      <Text style={styles.jackpotLabel}>Jackpot</Text>
       <Text style={styles.jackpot}>{game.jackpot}</Text>
       {game.nextDrawTime && (
-        <>
-          <Text style={styles.nextDrawLabel}>Next Draw</Text>
-          <Text style={styles.nextDraw}>
-            {new Date(game.nextDrawTime).toLocaleString()}
-          </Text>
-        </>
-      )}
-      {lastDraw && (
-        <>
-          <Text style={styles.lastDrawLabel}>
-            Last Draw: #{lastDraw.draw_number}
-          </Text>
-          <Text style={styles.lastDrawLabel}>Winning Numbers</Text>
-          <Text style={styles.lastDraw}>
-            {lastDraw.winning_numbers.join(" - ")}
-          </Text>
-          {lastDraw.supplementary_numbers?.length ? (
-            <>
-              <Text style={styles.lastDrawLabel}>Supps</Text>
-              <Text style={styles.lastDraw}>
-                {lastDraw.supplementary_numbers.join(" - ")}
-              </Text>
-            </>
-          ) : lastDraw.powerball !== null &&
-            lastDraw.powerball !== undefined ? (
-            <>
-              <Text style={styles.lastDrawLabel}>Powerball</Text>
-              <Text style={styles.lastDraw}>{lastDraw.powerball}</Text>
-            </>
-          ) : null}
-        </>
+        <Text style={styles.nextDraw}>
+          {new Date(game.nextDrawTime).toLocaleString()}
+        </Text>
       )}
     </Pressable>
   );

--- a/components/GameGrid.tsx
+++ b/components/GameGrid.tsx
@@ -13,7 +13,7 @@ export default function GameGrid({ games, onSelectGame }: GameGridProps) {
     <FlatList<Game>
       data={games}
       keyExtractor={(item: Game) => item.id}
-      numColumns={1}
+      numColumns={2}
       contentContainerStyle={styles.list}
       renderItem={({ item }: { item: Game }) => (
         <GameCard game={item} onPress={() => onSelectGame(item)} />


### PR DESCRIPTION
## Summary
- trim GameCard UI to show only logo, jackpot and next draw date
- show game cards two per row in `GameGrid`
- update tests for new compact card layout

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68613c223ae8832f97b4d6aec20ecb6d