### PR TITLE
Apply game-specific colors

### DIFF
--- a/app/game/[id]/draws.tsx
+++ b/app/game/[id]/draws.tsx
@@ -6,6 +6,7 @@ import { useLocalSearchParams } from "expo-router";
 import { useTheme } from "../../../lib/theme";
 import { fetchRecentDraws, DrawResult } from "../../../lib/gamesApi";
 import { useGamesStore } from "../../../stores/useGamesStore";
+import { getGameColor } from "../../../lib/gameColors";
 
 export default function DrawsScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -30,7 +31,9 @@ export default function DrawsScreen() {
     () =>
       StyleSheet.create({
         container: {
-          backgroundColor: tokens.color.brand.primary.value,
+          backgroundColor: game
+            ? getGameColor(game.name)
+            : tokens.color.brand.primary.value,
           flex: 1,
           padding: 16,
         },
@@ -43,7 +46,7 @@ export default function DrawsScreen() {
           textAlign: "center",
         },
       }),
-    [tokens],
+    [tokens, game],
   );
 
   return (

--- a/app/game/[id]/hotcold.tsx
+++ b/app/game/[id]/hotcold.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../../lib/gamesApi";
 import { calculateHotColdNumbers } from "../../../lib/hotCold";
 import { useGamesStore } from "../../../stores/useGamesStore";
+import { getGameColor } from "../../../lib/gameColors";
 
 export default function HotColdScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -80,7 +81,9 @@ export default function HotColdScreen() {
     () =>
       StyleSheet.create({
         container: {
-          backgroundColor: tokens.color.brand.primary.value,
+          backgroundColor: game
+            ? getGameColor(game.name)
+            : tokens.color.brand.primary.value,
           flex: 1,
           padding: 16,
         },
@@ -96,7 +99,7 @@ export default function HotColdScreen() {
           textAlign: "center",
         },
       }),
-    [tokens],
+    [tokens, game],
   );
 
   return (

--- a/app/game/[id]/options.tsx
+++ b/app/game/[id]/options.tsx
@@ -18,6 +18,7 @@ import { generateSet } from "../../../lib/generator";
 import { useGeneratedNumbersStore } from "../../../stores/useGeneratedNumbersStore";
 import type { GameConfig } from "../../../lib/gameConfigs";
 import { useGamesStore } from "../../../stores/useGamesStore";
+import { getGameColor } from "../../../lib/gameColors";
 import * as FileSystem from "expo-file-system";
 
 export default function GameOptionsScreen() {
@@ -151,7 +152,9 @@ export default function GameOptionsScreen() {
       StyleSheet.create({
         button: {
           alignItems: "center",
-          backgroundColor: tokens.color.brand.primary.value,
+          backgroundColor: game
+            ? getGameColor(game.name)
+            : tokens.color.brand.primary.value,
           borderRadius: 8,
           padding: 12,
         },
@@ -165,15 +168,22 @@ export default function GameOptionsScreen() {
           textAlign: "center",
         },
         container: {
-          backgroundColor: tokens.color.brand.primary.value,
+          backgroundColor: game
+            ? getGameColor(game.name)
+            : tokens.color.brand.primary.value,
           flex: 1,
           padding: 16,
         },
         disabled: { opacity: 0.5 },
         header: {
+          backgroundColor: game
+            ? getGameColor(game.name)
+            : tokens.color.brand.primary.value,
+          borderRadius: 8,
           flexDirection: "row",
           justifyContent: "space-between",
           marginBottom: 16,
+          padding: 8,
         },
         numbers: {
           color: tokens.color.neutral["0"].value,
@@ -198,7 +208,7 @@ export default function GameOptionsScreen() {
         },
         toggleText: { color: tokens.color.neutral["0"].value, marginLeft: 8 },
       }),
-    [tokens],
+    [tokens, game],
   );
 
   return (

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -13,10 +13,10 @@ import {
 } from "react-native";
 import type { Game } from "../lib/gamesApi";
 import placeholder from "../assets/placeholder.png";
+import { getGameColor } from "../lib/gameColors";
 
 const CARD_BG = "#1E1E1E";
 const WHITE = "#FFFFFF";
-const ACCENT = "#7B1FA2";
 
 type GameCardProps = {
   game: Game;
@@ -43,7 +43,7 @@ export default function GameCard({ game, onPress }: GameCardProps) {
           fontWeight: "700",
         },
         logo: {
-          backgroundColor: ACCENT,
+          backgroundColor: getGameColor(game.name),
           borderRadius: 64,
           height: 96,
           marginBottom: 10,
@@ -56,7 +56,7 @@ export default function GameCard({ game, onPress }: GameCardProps) {
           marginTop: 4,
         },
       }),
-    [],
+    [game.name],
   );
 
   const [loading, setLoading] = useState(!!game.logoUrl);

--- a/lib/gameColors.ts
+++ b/lib/gameColors.ts
@@ -1,0 +1,10 @@
+export const gameColors: Record<string, string> = {
+  "Saturday Lotto": "#cf0010",
+  "Oz Lotto": "#015700",
+  Powerball: "#1d3782",
+  "Set for Life": "#3bb3c3",
+  "Weekday Windfall": "#573888",
+};
+
+export const getGameColor = (name: string): string =>
+  gameColors[name] ?? "#7B1FA2";


### PR DESCRIPTION
## Summary
- add `gameColors` helper mapping
- color circles per game on home screen
- use matching colors for game options, draws and hot/cold screens

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686296ad7f40832f8d8c5545f93b1248