### PR TITLE
Adjust game options colors

### DIFF
--- a/app/game/[id]/options.tsx
+++ b/app/game/[id]/options.tsx
@@ -19,6 +19,7 @@ import { useGeneratedNumbersStore } from "../../../stores/useGeneratedNumbersSto
 import type { GameConfig } from "../../../lib/gameConfigs";
 import { useGamesStore } from "../../../stores/useGamesStore";
 import { getGameColor } from "../../../lib/gameColors";
+import { SCREEN_BG } from "../../../lib/constants";
 import * as FileSystem from "expo-file-system";
 
 export default function GameOptionsScreen() {
@@ -168,9 +169,7 @@ export default function GameOptionsScreen() {
           textAlign: "center",
         },
         container: {
-          backgroundColor: game
-            ? getGameColor(game.name)
-            : tokens.color.brand.primary.value,
+          backgroundColor: SCREEN_BG,
           flex: 1,
           padding: 16,
         },

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -7,13 +7,13 @@ import HomeTopBar from "../components/HomeTopBar";
 import BottomNav from "../components/BottomNav";
 import ComingSoon from "../components/ComingSoon";
 import GameGrid from "../components/GameGrid";
+import { SCREEN_BG } from "../lib/constants";
 import { Game, fetchGames } from "../lib/gamesApi";
 import { useRouter } from "expo-router";
 import { useGamesStore } from "../stores/useGamesStore";
 import { useRegionStore } from "../stores/useRegionStore";
 import { REGION_PLACEHOLDER_IMAGES, REGION_LABELS } from "../lib/regionConfig";
 
-const SCREEN_BG = "#121212";
 const WHITE = "#FFFFFF";
 
 const ERROR_COLOR = "#FF6666";

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,1 @@
+export const SCREEN_BG = "#121212";


### PR DESCRIPTION
## Summary
- share `SCREEN_BG` constant in a new module
- use `SCREEN_BG` for the index screen container
- colour the game options screen body with `SCREEN_BG`

## Testing
- `yarn lint`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6863077536b4832f94eff543779d80e1