### PR TITLE
feat: add global bottom navigation

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
 import { ThemeProvider } from "../lib/theme";
 import Header from "../components/Header";
+import BottomNav from "../components/BottomNav";
 import { View, StyleSheet, Platform } from "react-native";
 
 export default function Layout() {
@@ -13,9 +14,12 @@ export default function Layout() {
       <SafeAreaProvider>
         <StatusBar style="auto" />
         <View style={styles.container}>
-          <Stack screenOptions={{ header: () => <Header /> }}>
-            <Stack.Screen name="index" options={{ headerShown: false }} />
-          </Stack>
+          <View style={styles.stackContainer}>
+            <Stack screenOptions={{ header: () => <Header /> }}>
+              <Stack.Screen name="index" options={{ headerShown: false }} />
+            </Stack>
+          </View>
+          <BottomNav />
         </View>
       </SafeAreaProvider>
     </ThemeProvider>
@@ -29,5 +33,8 @@ const styles = StyleSheet.create({
     ...Platform.select({
       web: { maxWidth: 1280, marginLeft: "auto", marginRight: "auto" },
     }),
+  },
+  stackContainer: {
+    flex: 1,
   },
 });

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -4,7 +4,6 @@ import { StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
 import HomeTopBar from "../components/HomeTopBar";
-import BottomNav from "../components/BottomNav";
 import ComingSoon from "../components/ComingSoon";
 import GameGrid from "../components/GameGrid";
 import { SCREEN_BG } from "../lib/constants";
@@ -80,7 +79,6 @@ export default function IndexScreen() {
           region={REGION_LABELS[region]}
         />
       )}
-      <BottomNav />
     </SafeAreaView>
   );
 }

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -1,38 +1,41 @@
 /* eslint-disable react-native/no-color-literals, react-native/sort-styles */
-import React, { useState } from "react";
+import React from "react";
 import { View, Pressable, Text, StyleSheet } from "react-native";
+import { useRouter, usePathname } from "expo-router";
 
 const BLACK = "#000000";
 const GREY = "#B0B0B0";
 const PURPLE = "#7B1FA2";
 
 const NAV_ITEMS = [
-  { key: "home", icon: "🏠", label: "Home" },
-  { key: "draws", icon: "📜", label: "Draws" },
-  { key: "stats", icon: "📊", label: "Stats" },
-  { key: "settings", icon: "⚙️", label: "Settings" },
+  { key: "home", icon: "🏠", label: "Home", path: "/" },
+  { key: "settings", icon: "⚙️", label: "Settings", path: "/settings" },
 ];
 
 export default function BottomNav() {
-  const [active, setActive] = useState("home");
+  const router = useRouter();
+  const pathname = usePathname();
 
   return (
     <View style={styles.container}>
-      {NAV_ITEMS.map((item) => (
-        <Pressable
-          key={item.key}
-          style={styles.item}
-          onPress={() => setActive(item.key)}
-          accessibilityLabel={item.label}
-        >
-          <Text style={[styles.icon, active === item.key && styles.active]}>
-            {item.icon}
-          </Text>
-          <Text style={[styles.label, active === item.key && styles.active]}>
-            {item.label}
-          </Text>
-        </Pressable>
-      ))}
+      {NAV_ITEMS.map((item) => {
+        const isActive = pathname === item.path;
+        return (
+          <Pressable
+            key={item.key}
+            style={styles.item}
+            onPress={() => router.navigate(item.path)}
+            accessibilityLabel={item.label}
+          >
+            <Text style={[styles.icon, isActive && styles.active]}>
+              {item.icon}
+            </Text>
+            <Text style={[styles.label, isActive && styles.active]}>
+              {item.label}
+            </Text>
+          </Pressable>
+        );
+      })}
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- add `BottomNav` to the global layout so it appears on every screen
- simplify bottom navigation items to Home and Settings
- wire navigation to home and settings

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68630b7af578832fb12b73705fb51431