### PR TITLE
Resolve lint warnings in tests

### DIFF
--- a/src/components/RegionPicker.tsx
+++ b/src/components/RegionPicker.tsx
@@ -25,7 +25,6 @@ export default function RegionPicker({
 
   const labelFor = (r: Region) => REGION_LABELS[r];
 
-  // eslint-disable-next-line react-native/no-unused-styles
   const styles = useMemo(
     () =>
       StyleSheet.create({

--- a/src/lib/__tests__/syncDrawsAll.test.ts
+++ b/src/lib/__tests__/syncDrawsAll.test.ts
@@ -22,17 +22,19 @@ test("syncAllGames processes draws using mocked fetch and supabase", async () =>
   const deleteMock = jest.fn(() => ({ in: () => Promise.resolve() }));
   const insertMock = jest.fn(() => Promise.resolve({ error: null }));
   const fromMock = jest.fn((table: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (table === "draws") return { upsert: upsertMock } as any;
+    if (table === "draws")
+      return { upsert: upsertMock } as { upsert: jest.Mock };
     if (table === "draw_results")
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return {
         delete: deleteMock,
         in: jest.fn().mockResolvedValue(undefined),
         insert: insertMock,
-      } as any;
+      } as {
+        delete: jest.Mock;
+        in: jest.Mock;
+        insert: jest.Mock;
+      };
     if (table === "games")
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return {
         select: jest.fn().mockReturnThis(),
         eq: jest.fn().mockReturnThis(),
@@ -40,12 +42,16 @@ test("syncAllGames processes draws using mocked fetch and supabase", async () =>
           data: { csv_url: "http://example.com" },
           error: null,
         }),
-      } as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return {} as any;
+      } as {
+        select: jest.Mock;
+        eq: jest.Mock;
+        maybeSingle: jest.Mock;
+      };
+    return {} as Record<string, never>;
   });
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const createClientMock = jest.fn(() => ({ from: fromMock }) as any);
+  const createClientMock = jest.fn(
+    () => ({ from: fromMock }) as { from: typeof fromMock },
+  );
   jest.doMock("@supabase/supabase-js", () => ({
     createClient: createClientMock,
   }));

--- a/src/lib/__tests__/syncHotCold.extra.test.ts
+++ b/src/lib/__tests__/syncHotCold.extra.test.ts
@@ -56,19 +56,17 @@ test("syncAllHotCold reads games and updates records", async () => {
   }));
   const upsertHotCold = jest.fn(() => Promise.resolve({ error: null }));
   const fromMock = jest.fn((table: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (table === "games") return { select: selectGames } as any;
+    if (table === "games")
+      return { select: selectGames } as { select: jest.Mock };
     if (table === "draws")
-      return {
-        select: selectDraws,
-      } as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (table === "hot_cold_numbers") return { upsert: upsertHotCold } as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return {} as any;
+      return { select: selectDraws } as { select: jest.Mock };
+    if (table === "hot_cold_numbers")
+      return { upsert: upsertHotCold } as { upsert: jest.Mock };
+    return {} as Record<string, never>;
   });
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const createClientMock = jest.fn(() => ({ from: fromMock }) as any);
+  const createClientMock = jest.fn(
+    () => ({ from: fromMock }) as { from: typeof fromMock },
+  );
   jest.doMock("@supabase/supabase-js", () => ({
     createClient: createClientMock,
   }));

--- a/src/lib/__tests__/syncHotCold.test.ts
+++ b/src/lib/__tests__/syncHotCold.test.ts
@@ -2,7 +2,7 @@ describe("computeHotCold", () => {
   test("calculates hot and cold numbers from rows", () => {
     process.env.SUPABASE_URL = "http://localhost";
     process.env.SUPABASE_ANON_KEY = "anon";
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { computeHotCold } = require("../syncHotCold");
     const rows = [
       { winning_numbers: [1, 2, 3], supplementary_numbers: [7], powerball: 9 },


### PR DESCRIPTION
## Summary
- remove stray eslint directives in RegionPicker and test files
- replace `as any` casts in tests with typed mocks
- clean up indentation in syncHotCold test

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6863bdc360e0832f8225fc483c92622b