### PR TITLE
Switch weight generation to Supabase

### DIFF
--- a/src/generation/weight_generation.py
+++ b/src/generation/weight_generation.py
@@ -11,17 +11,66 @@ import numpy as np
 import json
 import os
 from datetime import datetime
+import requests
 
 # ──────────── Configuration ────────────
-DRAW_CSV_PATH    = "data/draw_history.csv"  # your draws CSV
-DECAY_HALF_LIFE  = 120                     # in draws
-GAME_ID          = "saturday_lotto"        # used for output filename
-OUTPUT_DIR       = "assets/weights"         # where to save JSON
+# Supabase connection details. Use service role if available.
+SUPABASE_URL = os.getenv("SUPABASE_URL") or os.getenv("EXPO_PUBLIC_SUPABASE_URL")
+SUPABASE_KEY = (
+    os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    or os.getenv("SUPABASE_ANON_KEY")
+    or os.getenv("EXPO_PUBLIC_SUPABASE_ANON_KEY")
+)
+
+DECAY_HALF_LIFE = int(os.getenv("DECAY_HALF_LIFE", "120"))  # in draws
+GAME_UUID = os.getenv("GAME_UUID") or "11111111-1111-1111-1111-111111111111"
+GAME_SLUG = os.getenv("GAME_SLUG") or "saturday_lotto"
+OUTPUT_DIR = "assets/weights"  # where to save JSON
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
+if not SUPABASE_URL or not SUPABASE_KEY:
+    raise RuntimeError("Supabase credentials are missing")
+
 # ──────────── Load Data ────────────
-df = pd.read_csv(DRAW_CSV_PATH, parse_dates=["draw_date"])
-df = df.sort_values("draw_date", ascending=False).reset_index(drop=True)
+headers = {"apikey": SUPABASE_KEY, "Authorization": f"Bearer {SUPABASE_KEY}"}
+rows = []
+batch = 1000
+offset = 0
+params = {
+    "select": "draw_date,draw_results(number,ball_types(name))",
+    "game_id": f"eq.{GAME_UUID}",
+    "order": "draw_date.desc",
+}
+while True:
+    rng = f"{offset}-{offset + batch - 1}"
+    h = {**headers, "Range-Unit": "items", "Range": rng}
+    res = requests.get(f"{SUPABASE_URL}/rest/v1/draws", headers=h, params=params)
+    res.raise_for_status()
+    page = res.json()
+    if not page:
+        break
+    rows.extend(page)
+    if len(page) < batch:
+        break
+    offset += batch
+
+records = []
+for r in rows:
+    nums = sorted(
+        d["number"]
+        for d in r.get("draw_results", [])
+        if d.get("ball_types", {}).get("name") == "main"
+    )
+    rec = {"draw_date": r["draw_date"]}
+    for i, n in enumerate(nums, start=1):
+        rec[f"ball{i}"] = n
+    records.append(rec)
+
+df = (
+    pd.DataFrame.from_records(records)
+    .sort_values("draw_date", ascending=False)
+    .reset_index(drop=True)
+)
 
 # ──────────── Compute Decay Weights ────────────
 df["draw_index"]   = df.index
@@ -72,7 +121,7 @@ output = {
     "weights": weight_list
 }
 
-out_path = f"{OUTPUT_DIR}/{GAME_ID}.json"
+out_path = f"{OUTPUT_DIR}/{GAME_SLUG}.json"
 with open(out_path, "w") as f:
     json.dump(output, f, indent=2)
 


### PR DESCRIPTION
## Summary
- use Supabase REST API for draw history
- remove obsolete CSV reference

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68645c5fd7a4832f8a343cc75755042c