### PR TITLE
Fix option screens colours

### DIFF
--- a/app/game/[id]/draws.tsx
+++ b/app/game/[id]/draws.tsx
@@ -6,7 +6,7 @@ import { useLocalSearchParams } from "expo-router";
 import { useTheme } from "../../../src/lib/theme";
 import { fetchRecentDraws, DrawResult } from "../../../src/lib/gamesApi";
 import { useGamesStore } from "../../../src/stores/useGamesStore";
-import { getGameColor } from "../../../src/lib/gameColors";
+import { SCREEN_BG } from "../../../src/lib/constants";
 
 export default function DrawsScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -30,9 +30,7 @@ export default function DrawsScreen() {
     () =>
       StyleSheet.create({
         container: {
-          backgroundColor: game
-            ? getGameColor(game.name)
-            : tokens.color.brand.primary.value,
+          backgroundColor: SCREEN_BG,
           flex: 1,
           padding: 16,
         },

--- a/app/game/[id]/hotcold.tsx
+++ b/app/game/[id]/hotcold.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../../src/lib/gamesApi";
 import { calculateHotColdNumbers } from "../../../src/lib/hotCold";
 import { useGamesStore } from "../../../src/stores/useGamesStore";
-import { getGameColor } from "../../../src/lib/gameColors";
+import { SCREEN_BG } from "../../../src/lib/constants";
 
 export default function HotColdScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -80,9 +80,7 @@ export default function HotColdScreen() {
     () =>
       StyleSheet.create({
         container: {
-          backgroundColor: game
-            ? getGameColor(game.name)
-            : tokens.color.brand.primary.value,
+          backgroundColor: SCREEN_BG,
           flex: 1,
           padding: 16,
         },

--- a/app/game/[id]/options.tsx
+++ b/app/game/[id]/options.tsx
@@ -19,9 +19,7 @@ import { useGeneratedNumbersStore } from "../../../src/stores/useGeneratedNumber
 import type { GameConfig } from "../../../src/lib/gameConfigs";
 import { useGamesStore } from "../../../src/stores/useGamesStore";
 import { getGameColor } from "../../../src/lib/gameColors";
-import { SCREEN_BG } from "../../../src/lib/constants";
-
-const BLACK = "#000000";
+import { SCREEN_BG, CARD_BG } from "../../../src/lib/constants";
 import * as FileSystem from "expo-file-system";
 
 export default function GameOptionsScreen() {
@@ -154,9 +152,7 @@ export default function GameOptionsScreen() {
       StyleSheet.create({
         button: {
           alignItems: "center",
-          backgroundColor: game
-            ? getGameColor(game.name)
-            : tokens.color.brand.primary.value,
+          backgroundColor: CARD_BG,
           borderRadius: 8,
           padding: 12,
         },
@@ -176,7 +172,9 @@ export default function GameOptionsScreen() {
         },
         disabled: { opacity: 0.5 },
         header: {
-          backgroundColor: BLACK,
+          backgroundColor: game
+            ? getGameColor(game.name)
+            : tokens.color.brand.primary.value,
           borderRadius: 8,
           flexDirection: "row",
           justifyContent: "space-between",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,1 +1,2 @@
 export const SCREEN_BG = "#121212";
+export const CARD_BG = "#1E1E1E";


### PR DESCRIPTION
## Summary
- use shared CARD_BG constant
- make game option headers use the game colour
- keep draw and hot/cold screens dark

## Testing
- `yarn lint`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6865038465b4832f896aee7257c1709f