### PR TITLE
fix url normalization regex

### DIFF
--- a/src/lib/gamesApi.ts
+++ b/src/lib/gamesApi.ts
@@ -42,7 +42,8 @@ export interface GameRow {
 
 /** Collapse any “//” in the pathname (preserving “https://”) */
 function normalizeUrl(url: string): string {
-  return url.replace(/([^:]\/)\/+/g, "$1");
+  // Collapse duplicate slashes except after the protocol
+  return url.replace(/([^:])\/{2,}/g, "$1/");
 }
 
 export async function fetchGames(force = false): Promise<Game[]> {


### PR DESCRIPTION
## Summary
- correct regex in `normalizeUrl` to avoid truncating domain names

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686509c9dcd4832fb2bdb80de378cc72