### PR TITLE
Implement global header and adjust home UI

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,7 +16,7 @@ export default function Layout() {
         <View style={styles.container}>
           <View style={styles.stackContainer}>
             <Stack screenOptions={{ header: () => <Header /> }}>
-              <Stack.Screen name="index" options={{ headerShown: false }} />
+              <Stack.Screen name="index" />
             </Stack>
           </View>
           <BottomNav />

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useMemo } from "react";
 import { StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
-import HomeTopBar from "../src/components/HomeTopBar";
+import RegionPicker from "../src/components/RegionPicker";
 import ComingSoon from "../src/components/ComingSoon";
 import GameGrid from "../src/components/GameGrid";
 import { SCREEN_BG } from "../src/lib/constants";
@@ -56,6 +56,7 @@ export default function IndexScreen() {
         debugText: { color: WHITE, fontSize: 18 },
         errorText: { color: ERROR_COLOR, fontSize: 18 },
         gridContainer: { flex: 1, paddingVertical: 8 },
+        pickerContainer: { padding: 8 },
       }),
     [],
   );
@@ -63,7 +64,9 @@ export default function IndexScreen() {
   return (
     <SafeAreaView style={styles.container}>
       <StatusBar style="light" />
-      <HomeTopBar />
+      <View style={styles.pickerContainer}>
+        <RegionPicker variant="header" />
+      </View>
 
       {region === "AU" ? (
         <View style={styles.gridContainer}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,12 @@
 /* eslint-disable react-native/no-unused-styles */
-import { View, Pressable, StyleSheet, Platform, Image } from "react-native";
+import { View, StyleSheet, Platform, Image } from "react-native";
 import { useMemo } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useTheme } from "../lib/theme";
-import { useRouter } from "expo-router";
-import { Text } from "react-native";
 import logo from "../../assets/logo.png"; // Local PNG fallback logo for header
 
+const BLACK = "#000000";
+
 export default function Header() {
-  const { tokens } = useTheme();
-  const router = useRouter();
   const insets = useSafeAreaInsets();
 
   const styles = useMemo(
@@ -17,23 +14,19 @@ export default function Header() {
       StyleSheet.create({
         container: {
           alignItems: "center",
-          backgroundColor: tokens.color.brand.primary.value,
+          backgroundColor: BLACK,
           flexDirection: "row",
           height: TOP_BAR_HEIGHT + insets.top,
           justifyContent: "space-between",
           paddingHorizontal: 5,
           paddingTop: insets.top,
         },
-        icon: {
-          color: tokens.color.neutral["0"].value,
-          fontSize: 20,
-        },
         logo: {
           height: 80,
           width: 160,
         },
       }),
-    [tokens, insets.top],
+    [insets.top],
   );
 
   return (
@@ -44,9 +37,6 @@ export default function Header() {
         accessibilityLabel="Powerpick logo"
         resizeMode="contain"
       />
-      <Pressable onPress={() => router.navigate("/settings")}>
-        <Text style={styles.icon}>☰</Text>
-      </Pressable>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- tweak `Header` component and drop settings button
- update layout to show `Header` on all screens
- move home screen region picker below the header

## Testing
- `yarn lint`
- `yarn format`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6865103188e0832f90b18bd5827945b6