### PR TITLE
Update region picker behavior

### DIFF
--- a/app/__tests__/Index.test.tsx
+++ b/app/__tests__/Index.test.tsx
@@ -11,7 +11,10 @@ jest.mock("expo-constants", () => ({
 }));
 
 // Avoid requiring the real expo-router module in tests
-jest.mock("expo-router", () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => "/",
+}));
 
 // Simplify native modules that rely on browser APIs
 jest.mock("expo-status-bar", () => ({ StatusBar: () => null }));

--- a/app/__tests__/RegionPicker.test.tsx
+++ b/app/__tests__/RegionPicker.test.tsx
@@ -5,6 +5,18 @@ import { ThemeProvider } from "../../src/lib/theme";
 import RegionPicker from "../../src/components/RegionPicker";
 import { useRegionStore } from "../../src/stores/useRegionStore";
 
+jest.mock("expo-router", () => {
+  const navigate = jest.fn();
+  return {
+    __esModule: true,
+    useRouter: () => ({ navigate }),
+    usePathname: () => "/other",
+    navigateMock: navigate,
+  };
+});
+
+import { navigateMock } from "expo-router";
+
 const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <PaperProvider>
     <ThemeProvider>{children}</ThemeProvider>
@@ -13,6 +25,7 @@ const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 
 describe("RegionPicker", () => {
   beforeEach(() => {
+    navigateMock.mockClear();
     useRegionStore.setState({
       region: "AU",
       setRegion: (r) => useRegionStore.setState({ region: r }),
@@ -31,6 +44,7 @@ describe("RegionPicker", () => {
     await waitFor(() => expect(useRegionStore.getState().region).toBe("US"));
     expect(queryByText("Australia")).toBeNull();
     expect(getByText("USA")).toBeTruthy();
+    expect(navigateMock).toHaveBeenCalledWith("/");
   });
 
   test("selecting option only sets region once", async () => {
@@ -46,5 +60,6 @@ describe("RegionPicker", () => {
 
     await waitFor(() => expect(useRegionStore.getState().region).toBe("US"));
     expect(setRegionMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,7 +16,7 @@ export default function Layout() {
         <View style={styles.container}>
           <View style={styles.stackContainer}>
             <Stack screenOptions={{ header: () => <Header /> }}>
-              <Stack.Screen name="index" />
+              <Stack.Screen name="index" options={{ headerShown: false }} />
             </Stack>
           </View>
           <BottomNav />

--- a/src/components/RegionPicker.tsx
+++ b/src/components/RegionPicker.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable react-native/no-unused-styles */
 import React, { useState, useMemo } from "react";
 import { View, Text, Pressable, Modal, StyleSheet } from "react-native";
+import { useRouter, usePathname } from "expo-router";
 
 import { useTheme } from "../lib/theme";
 import { useRegionStore, Region } from "../stores/useRegionStore";
@@ -17,6 +18,8 @@ export default function RegionPicker({
   variant?: "default" | "header";
 }) {
   const { tokens } = useTheme();
+  const router = useRouter();
+  const pathname = usePathname();
   const region = useRegionStore((s) => s.region);
   const setRegion = useRegionStore((s) => s.setRegion);
   const [visible, setVisible] = useState(false);
@@ -112,6 +115,7 @@ export default function RegionPicker({
                   e.stopPropagation();
                   setRegion(opt);
                   setVisible(false);
+                  if (pathname !== "/") router.navigate("/");
                 }}
               >
                 <Text style={styles.optionText}>{labelFor(opt)}</Text>


### PR DESCRIPTION
## Summary
- hide app header on the home screen
- navigate home when changing region away from the home screen
- update RegionPicker tests for navigation logic
- fix IndexScreen tests with new expo-router mock

## Testing
- `yarn format:check`
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6866318fad68832f8d191ae1de31b0a8