### PR TITLE
Fix next_draw_time updates

### DIFF
--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -4,265 +4,265 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[]
+  | Json[];
 
 export type Database = {
   public: {
     Tables: {
       ball_types: {
         Row: {
-          game_id: string
-          id: number
-          name: string
-          sort_order: number | null
-        }
+          game_id: string;
+          id: number;
+          name: string;
+          sort_order: number | null;
+        };
         Insert: {
-          game_id: string
-          id?: number
-          name: string
-          sort_order?: number | null
-        }
+          game_id: string;
+          id?: number;
+          name: string;
+          sort_order?: number | null;
+        };
         Update: {
-          game_id?: string
-          id?: number
-          name?: string
-          sort_order?: number | null
-        }
+          game_id?: string;
+          id?: number;
+          name?: string;
+          sort_order?: number | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "ball_types_game_id_fkey"
-            columns: ["game_id"]
-            isOneToOne: false
-            referencedRelation: "games"
-            referencedColumns: ["id"]
+            foreignKeyName: "ball_types_game_id_fkey";
+            columns: ["game_id"];
+            isOneToOne: false;
+            referencedRelation: "games";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       draw_results: {
         Row: {
-          ball_type_id: number
-          draw_id: number
-          id: number
-          number: number
-        }
+          ball_type_id: number;
+          draw_id: number;
+          id: number;
+          number: number;
+        };
         Insert: {
-          ball_type_id: number
-          draw_id: number
-          id?: number
-          number: number
-        }
+          ball_type_id: number;
+          draw_id: number;
+          id?: number;
+          number: number;
+        };
         Update: {
-          ball_type_id?: number
-          draw_id?: number
-          id?: number
-          number?: number
-        }
+          ball_type_id?: number;
+          draw_id?: number;
+          id?: number;
+          number?: number;
+        };
         Relationships: [
           {
-            foreignKeyName: "draw_results_ball_type_id_fkey"
-            columns: ["ball_type_id"]
-            isOneToOne: false
-            referencedRelation: "ball_types"
-            referencedColumns: ["id"]
+            foreignKeyName: "draw_results_ball_type_id_fkey";
+            columns: ["ball_type_id"];
+            isOneToOne: false;
+            referencedRelation: "ball_types";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "draw_results_draw_id_fkey"
-            columns: ["draw_id"]
-            isOneToOne: false
-            referencedRelation: "draws"
-            referencedColumns: ["id"]
+            foreignKeyName: "draw_results_draw_id_fkey";
+            columns: ["draw_id"];
+            isOneToOne: false;
+            referencedRelation: "draws";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       draw_timetable: {
         Row: {
-          draw_dow: number
-          game_id: string
-          local_time: string
-          time_zone: string
-        }
+          draw_dow: number;
+          game_id: string;
+          local_time: string;
+          time_zone: string;
+        };
         Insert: {
-          draw_dow: number
-          game_id: string
-          local_time: string
-          time_zone: string
-        }
+          draw_dow: number;
+          game_id: string;
+          local_time: string;
+          time_zone: string;
+        };
         Update: {
-          draw_dow?: number
-          game_id?: string
-          local_time?: string
-          time_zone?: string
-        }
+          draw_dow?: number;
+          game_id?: string;
+          local_time?: string;
+          time_zone?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "draw_timetable_game_id_fkey"
-            columns: ["game_id"]
-            isOneToOne: false
-            referencedRelation: "games"
-            referencedColumns: ["id"]
+            foreignKeyName: "draw_timetable_game_id_fkey";
+            columns: ["game_id"];
+            isOneToOne: false;
+            referencedRelation: "games";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       draws: {
         Row: {
-          created_at: string | null
-          draw_date: string
-          draw_number: number
-          game_id: string
-          id: number
-        }
+          created_at: string | null;
+          draw_date: string;
+          draw_number: number;
+          game_id: string;
+          id: number;
+        };
         Insert: {
-          created_at?: string | null
-          draw_date: string
-          draw_number: number
-          game_id: string
-          id?: number
-        }
+          created_at?: string | null;
+          draw_date: string;
+          draw_number: number;
+          game_id: string;
+          id?: number;
+        };
         Update: {
-          created_at?: string | null
-          draw_date?: string
-          draw_number?: number
-          game_id?: string
-          id?: number
-        }
+          created_at?: string | null;
+          draw_date?: string;
+          draw_number?: number;
+          game_id?: string;
+          id?: number;
+        };
         Relationships: [
           {
-            foreignKeyName: "draws_game_id_fkey"
-            columns: ["game_id"]
-            isOneToOne: false
-            referencedRelation: "games"
-            referencedColumns: ["id"]
+            foreignKeyName: "draws_game_id_fkey";
+            columns: ["game_id"];
+            isOneToOne: false;
+            referencedRelation: "games";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       games: {
         Row: {
-          created_at: string | null
-          csv_url: string | null
-          draw_day: string | null
-          draw_time: string | null
-          from_draw_number: number
-          id: string
-          jackpot: number | null
-          logo_url: string | null
-          main_count: number | null
-          main_max: number | null
-          name: string
-          next_draw_time: string | null
-          powerball_max: number | null
-          region: string
-          supp_count: number | null
-          supp_max: number | null
-          time_zone: string | null
-        }
+          created_at: string | null;
+          csv_url: string | null;
+          draw_day: string | null;
+          draw_time: string | null;
+          from_draw_number: number;
+          id: string;
+          jackpot: number | null;
+          logo_url: string | null;
+          main_count: number | null;
+          main_max: number | null;
+          name: string;
+          next_draw_time: string | null;
+          powerball_max: number | null;
+          region: string;
+          supp_count: number | null;
+          supp_max: number | null;
+          time_zone: string | null;
+        };
         Insert: {
-          created_at?: string | null
-          csv_url?: string | null
-          draw_day?: string | null
-          draw_time?: string | null
-          from_draw_number: number
-          id?: string
-          jackpot?: number | null
-          logo_url?: string | null
-          main_count?: number | null
-          main_max?: number | null
-          name: string
-          next_draw_time?: string | null
-          powerball_max?: number | null
-          region: string
-          supp_count?: number | null
-          supp_max?: number | null
-          time_zone?: string | null
-        }
+          created_at?: string | null;
+          csv_url?: string | null;
+          draw_day?: string | null;
+          draw_time?: string | null;
+          from_draw_number: number;
+          id?: string;
+          jackpot?: number | null;
+          logo_url?: string | null;
+          main_count?: number | null;
+          main_max?: number | null;
+          name: string;
+          next_draw_time?: string | null;
+          powerball_max?: number | null;
+          region: string;
+          supp_count?: number | null;
+          supp_max?: number | null;
+          time_zone?: string | null;
+        };
         Update: {
-          created_at?: string | null
-          csv_url?: string | null
-          draw_day?: string | null
-          draw_time?: string | null
-          from_draw_number?: number
-          id?: string
-          jackpot?: number | null
-          logo_url?: string | null
-          main_count?: number | null
-          main_max?: number | null
-          name?: string
-          next_draw_time?: string | null
-          powerball_max?: number | null
-          region?: string
-          supp_count?: number | null
-          supp_max?: number | null
-          time_zone?: string | null
-        }
-        Relationships: []
-      }
+          created_at?: string | null;
+          csv_url?: string | null;
+          draw_day?: string | null;
+          draw_time?: string | null;
+          from_draw_number?: number;
+          id?: string;
+          jackpot?: number | null;
+          logo_url?: string | null;
+          main_count?: number | null;
+          main_max?: number | null;
+          name?: string;
+          next_draw_time?: string | null;
+          powerball_max?: number | null;
+          region?: string;
+          supp_count?: number | null;
+          supp_max?: number | null;
+          time_zone?: string | null;
+        };
+        Relationships: [];
+      };
       hot_cold_numbers: {
         Row: {
-          game_id: string
-          main_cold: number[]
-          main_hot: number[]
-          powerball_cold: number[] | null
-          powerball_hot: number[] | null
-          supp_cold: number[] | null
-          supp_hot: number[] | null
-          updated_at: string | null
-        }
+          game_id: string;
+          main_cold: number[];
+          main_hot: number[];
+          powerball_cold: number[] | null;
+          powerball_hot: number[] | null;
+          supp_cold: number[] | null;
+          supp_hot: number[] | null;
+          updated_at: string | null;
+        };
         Insert: {
-          game_id: string
-          main_cold: number[]
-          main_hot: number[]
-          powerball_cold?: number[] | null
-          powerball_hot?: number[] | null
-          supp_cold?: number[] | null
-          supp_hot?: number[] | null
-          updated_at?: string | null
-        }
+          game_id: string;
+          main_cold: number[];
+          main_hot: number[];
+          powerball_cold?: number[] | null;
+          powerball_hot?: number[] | null;
+          supp_cold?: number[] | null;
+          supp_hot?: number[] | null;
+          updated_at?: string | null;
+        };
         Update: {
-          game_id?: string
-          main_cold?: number[]
-          main_hot?: number[]
-          powerball_cold?: number[] | null
-          powerball_hot?: number[] | null
-          supp_cold?: number[] | null
-          supp_hot?: number[] | null
-          updated_at?: string | null
-        }
+          game_id?: string;
+          main_cold?: number[];
+          main_hot?: number[];
+          powerball_cold?: number[] | null;
+          powerball_hot?: number[] | null;
+          supp_cold?: number[] | null;
+          supp_hot?: number[] | null;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "hot_cold_numbers_game_id_fkey"
-            columns: ["game_id"]
-            isOneToOne: true
-            referencedRelation: "games"
-            referencedColumns: ["id"]
+            foreignKeyName: "hot_cold_numbers_game_id_fkey";
+            columns: ["game_id"];
+            isOneToOne: true;
+            referencedRelation: "games";
+            referencedColumns: ["id"];
           },
-        ]
-      }
-    }
+        ];
+      };
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
       dow_from_dayname: {
-        Args: { p_day: string }
-        Returns: number
-      }
-    }
+        Args: { p_day: string };
+        Returns: number;
+      };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type DefaultSchema = Database[Extract<keyof Database, "public">]
+type DefaultSchema = Database[Extract<keyof Database, "public">];
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof Database },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
     ? keyof (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
         Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
@@ -270,7 +270,7 @@ export type Tables<
 > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
   ? (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
       Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+      Row: infer R;
     }
     ? R
     : never
@@ -278,64 +278,64 @@ export type Tables<
         DefaultSchema["Views"])
     ? (DefaultSchema["Tables"] &
         DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
+        Row: infer R;
       }
       ? R
       : never
-    : never
+    : never;
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof Database },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
     ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
   ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+      Insert: infer I;
     }
     ? I
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
+        Insert: infer I;
       }
       ? I
       : never
-    : never
+    : never;
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof Database },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
     ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
   ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+      Update: infer U;
     }
     ? U
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
+        Update: infer U;
       }
       ? U
       : never
-    : never
+    : never;
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
     | keyof DefaultSchema["Enums"]
     | { schema: keyof Database },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
     ? keyof Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
@@ -343,14 +343,14 @@ export type Enums<
   ? Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
     ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+    : never;
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof Database },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof Database;
   }
     ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
@@ -358,10 +358,10 @@ export type CompositeTypes<
   ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+    : never;
 
 export const Constants = {
   public: {
     Enums: {},
   },
-} as const
+} as const;

--- a/supabase/migrations/20250704125453_base_table_setup.sql
+++ b/supabase/migrations/20250704125453_base_table_setup.sql
@@ -251,7 +251,7 @@ FROM (
   GROUP BY game_id
 ) sub
 WHERE g.id = sub.game_id
-  AND (g.next_draw_time IS NULL OR g.next_draw_time < NOW());
+  AND (g.next_draw_time IS NULL OR g.next_draw_time <= NOW());
 
 -- -------------------------------------------------------------------
 -- ★ Trigger: update_next_draw
@@ -278,7 +278,8 @@ BEGIN
 
   UPDATE public.games
     SET next_draw_time = next_ts
-  WHERE id = NEW.game_id;
+  WHERE id = NEW.game_id
+    AND (next_draw_time IS NULL OR next_ts > next_draw_time);
 
   RETURN NEW;
 END;

--- a/supabase/migrations/base_table_setup..sql
+++ b/supabase/migrations/base_table_setup..sql
@@ -251,7 +251,7 @@ FROM (
   GROUP BY game_id
 ) sub
 WHERE g.id = sub.game_id
-  AND (g.next_draw_time IS NULL OR g.next_draw_time < NOW());
+  AND (g.next_draw_time IS NULL OR g.next_draw_time <= NOW());
 
 -- -------------------------------------------------------------------
 -- ★ Trigger: update_next_draw
@@ -278,7 +278,8 @@ BEGIN
 
   UPDATE public.games
     SET next_draw_time = next_ts
-  WHERE id = NEW.game_id;
+  WHERE id = NEW.game_id
+    AND (next_draw_time IS NULL OR next_ts > next_draw_time);
 
   RETURN NEW;
 END;


### PR DESCRIPTION
## Summary
- ensure games table seed always updates next_draw_time
- prevent trigger from overwriting with older draw dates
- format supabase type definitions

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6867d43aab08832fadb932cf0df7c2e1