### PR TITLE
Add cross-platform deployment scaffolding

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -1,0 +1,20 @@
+name: Mobile Build
+on:
+  workflow_dispatch:
+  push:
+    branches: ["release/*"]
+
+jobs:
+  mobile-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - run: eas build --platform all --non-interactive
+      - run: eas submit -p all --latest
+        env:
+          EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PW }}
+          EXPO_GOOGLE_SERVICE_ACCOUNT: ${{ secrets.PLAY_JSON }}

--- a/README.md
+++ b/README.md
@@ -174,10 +174,19 @@ Schedule the Node sync scripts (`yarn sync-draws` and `yarn sync-hotcold`) on Ve
 
 **Checklist**
 
-- Add `vercel.json` with build and cron config.
-- Connect Expo EAS to your repo and store credentials in GitHub secrets.
-- Define Supabase cron SQL for any DB-local tasks.
-- Use GitHub Actions for mobile builds and heavy workflows.
+- `vercel.json` defines the web export and cron schedule.
+- `.github/workflows/mobile.yml` runs EAS builds on `release/*` branches.
+- Example Edge Function lives in `supabase/functions/rollup`.
+- Schedule DB-local tasks with `pg_cron` and trigger via Supabase.
+
+### Cross-Platform Deployment Checklist
+
+1. Confirm this repo's `origin` points to GitHub.
+2. Link the project to Vercel and enable previews.
+3. Create an Expo project and set `EXPO_TOKEN` in GitHub secrets.
+4. Deploy web builds to Vercel from `vercel.json`.
+5. Trigger native builds via `.github/workflows/mobile.yml`.
+6. Deploy Edge Functions from `supabase/functions` and schedule them with `pg_cron`.
 
 ---
 

--- a/api/nightly-stats.js
+++ b/api/nightly-stats.js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.status(200).json({ ok: true });
+}

--- a/api/refresh-cache.js
+++ b/api/refresh-cache.js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.status(200).json({ ok: true });
+}

--- a/app.json
+++ b/app.json
@@ -25,8 +25,10 @@
     },
     "web": {
       "favicon": "./assets/favicon.png",
-      "bundler": "metro"
+      "bundler": "metro",
+      "output": "static"
     },
-    "plugins": ["expo-router"]
+    "plugins": ["expo-router"],
+    "platforms": ["ios", "android", "web"]
   }
 }

--- a/index.web.js
+++ b/index.web.js
@@ -1,0 +1,10 @@
+import { registerRootComponent } from "expo";
+import { ExpoRoot } from "expo-router";
+
+const ctx = require.context("./app", true, /\.(tsx|ts|js)$/);
+
+function App() {
+  return <ExpoRoot context={ctx} />;
+}
+
+registerRootComponent(App);

--- a/supabase/functions/rollup/index.ts
+++ b/supabase/functions/rollup/index.ts
@@ -1,0 +1,8 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+
+serve(
+  () =>
+    new Response(JSON.stringify({ status: "ok" }), {
+      headers: { "Content-Type": "application/json" },
+    }),
+);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "buildCommand": "npx expo export --platform web",
+  "outputDirectory": "dist",
+  "framework": "expo",
+  "crons": [
+    { "path": "/api/refresh-cache", "schedule": "*/30 * * * *" },
+    { "path": "/api/nightly-stats", "schedule": "30 14 * * *" }
+  ]
+}


### PR DESCRIPTION
## Summary
- enable Expo web entry with `index.web.js`
- configure Expo web export and cron jobs via `vercel.json`
- add API route placeholders for Vercel cron
- add Supabase Edge Function example
- create EAS build workflow
- document deployment steps in README
- allow Expo web builds in `app.json`

## Testing
- `yarn format`
- `yarn format:check`
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686853825b34832f937cb031427f9681