### PR TITLE
Fix type checking errors

### DIFF
--- a/app/__tests__/GameOptions.test.tsx
+++ b/app/__tests__/GameOptions.test.tsx
@@ -31,11 +31,6 @@ jest.mock("expo-router", () => {
 });
 import { pushMock } from "expo-router";
 
-declare module "expo-router" {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const pushMock: jest.Mock<any, any>;
-}
-
 jest.mock("../../src/lib/generator");
 jest.mock("../../src/lib/gamesApi");
 

--- a/app/__tests__/RegionPicker.test.tsx
+++ b/app/__tests__/RegionPicker.test.tsx
@@ -17,11 +17,6 @@ jest.mock("expo-router", () => {
 
 import { navigateMock } from "expo-router";
 
-declare module "expo-router" {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const navigateMock: jest.Mock<any, any>;
-}
-
 const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <PaperProvider>
     <ThemeProvider>{children}</ThemeProvider>

--- a/supabase/functions/deno.d.ts
+++ b/supabase/functions/deno.d.ts
@@ -1,0 +1,4 @@
+declare module "https://deno.land/std@0.177.0/http/server.ts" {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function serve(...args: any[]): any;
+}

--- a/types/expo-router.d.ts
+++ b/types/expo-router.d.ts
@@ -1,0 +1,10 @@
+declare module "expo-router" {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export const navigateMock: jest.Mock<any, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export const pushMock: jest.Mock<any, any>;
+  export function useRouter(): any;
+  export function useLocalSearchParams<T extends Record<string, string>>(): T;
+  export function usePathname(): any;
+  export const Stack: any;
+}


### PR DESCRIPTION
## Summary
- remove inline module augmentations from tests
- add global Expo router typings for tests
- add Deno server stub declaration

## Testing
- `yarn tsc --noEmit`
- `yarn lint`
- `yarn format:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686862fed288832fa79806f1f43cc9fd