### PR TITLE
Limit app to Android and Web

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -48,27 +48,11 @@ jobs:
             --keystore-password "${{ secrets.KEYSTORE_PASSWORD }}" \
             --key-password "${{ secrets.KEY_PASSWORD }}"
 
-      # ── iOS credentials ────────────────────────────────────────────
-      - name: Decode iOS cert & provisioning profile
-        run: |
-          echo "${{ secrets.IOS_CERT_BASE64 }}"   | base64 --decode > distribution-cert.p12
-          echo "${{ secrets.IOS_PROFILE_BASE64 }}"| base64 --decode > profile.mobileprovision
-
-      - name: Setup iOS credentials for CI
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-        run: |
-          npx eas credentials:manager -p ios --non-interactive \
-            --distribution-certificate-path distribution-cert.p12 \
-            --certificate-password "${{ secrets.CERT_PASSWORD }}" \
-            --provisioning-profile-path profile.mobileprovision
-
       # ── Build & submit ─────────────────────────────────────────────
       - name: EAS Build
-        run: yarn eas build --platform all --non-interactive
+        run: yarn eas build --platform android --non-interactive
 
-      - name: Submit to stores
-        run: yarn eas submit -p all --latest
+      - name: Submit to Play Store
+        run: yarn eas submit -p android --latest
         env:
-          EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PW }}
-          EXPO_GOOGLE_SERVICE_ACCOUNT:      ${{ secrets.PLAY_JSON }}
+          EXPO_GOOGLE_SERVICE_ACCOUNT: ${{ secrets.PLAY_JSON }}

--- a/Docs/Phase_0.md
+++ b/Docs/Phase_0.md
@@ -4,7 +4,7 @@ This phase sets up the groundwork for development. Key objectives:
 
 1. **CI Pipeline** – lint, format and test on every pull request.
 2. **Design Tokens** – merge brand colours and spacing from `design/tokens.json`.
-3. **Skeleton App** – ensure the Expo project boots on iOS, Android and Web.
+3. **Skeleton App** – ensure the Expo project boots on Android and Web (iOS will follow later).
 4. **Documentation** – outline coding conventions and repository standards.
 
 Further planning details will be fleshed out in later versions of this document.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Predict smarter. Play responsibly.**
 
-> A cross‑platform (iOS · Android · Web) Expo/React Native app that delivers draw history, hot/cold analytics, and statistically‑weighted number suggestions for the world’s biggest lotteries—starting in **Australia** and expanding to the **USA** and **Europe**.
+> A cross‑platform (Android · Web) Expo/React Native app that delivers draw history, hot/cold analytics, and statistically‑weighted number suggestions for the world’s biggest lotteries—starting in **Australia** and expanding to the **USA** and **Europe**. _iOS support is planned for a future update._
 > _Powerpick does **not** sell tickets or guarantee winnings – it simply visualises probability so players can make informed, responsible choices._
 
 ![CI](https://github.com/<org>/powerpick/actions/workflows/ci.yml/badge.svg)
@@ -76,15 +76,15 @@ For deeper detail see [`Docs/Phase_0.md`](Docs/Phase_0.md) and [`Docs/WORKFLOW.m
 
 ## 🏗️ Tech Stack
 
-| Layer          | Choice                               | Why                                     |
-| -------------- | ------------------------------------ | --------------------------------------- |
-| **Frontend**   | Expo SDK (React Native + TypeScript) | Single code‑base across iOS/Android/Web |
-| **Navigation** | Expo Router                          | File‑based routing & deep‑linking       |
-| **State**      | React Context + Zustand              | Lightweight & persistent                |
-| **Backend**    | Supabase (PostgreSQL, RLS)           | Real‑time SQL without servers           |
-| **Auth**       | Supabase Auth (email/OAuth)          | Secure & fast setup                     |
-| **Hosting**    | Vercel (Web) · EAS Builds (mobile)   | CI/CD & OTA updates                     |
-| **Scripting**  | Python (pandas etc.)                 | Robust data ingestion                   |
+| Layer          | Choice                               | Why                                 |
+| -------------- | ------------------------------------ | ----------------------------------- |
+| **Frontend**   | Expo SDK (React Native + TypeScript) | Single code‑base across Android/Web |
+| **Navigation** | Expo Router                          | File‑based routing & deep‑linking   |
+| **State**      | React Context + Zustand              | Lightweight & persistent            |
+| **Backend**    | Supabase (PostgreSQL, RLS)           | Real‑time SQL without servers       |
+| **Auth**       | Supabase Auth (email/OAuth)          | Secure & fast setup                 |
+| **Hosting**    | Vercel (Web) · EAS Builds (mobile)   | CI/CD & OTA updates                 |
+| **Scripting**  | Python (pandas etc.)                 | Robust data ingestion               |
 
 ---
 
@@ -158,12 +158,12 @@ See [Docs/WORKFLOW.md](Docs/WORKFLOW.md) for the full guide. Key points:
 
 ## 🚀 Deployment & Scheduling
 
-Powerpick runs across several platforms:
+Powerpick runs across several surfaces. Android binaries are built via EAS (iOS coming soon):
 
 | Concern                              | Best surface                                        | Why                                                                |
 | ------------------------------------ | --------------------------------------------------- | ------------------------------------------------------------------ |
 | Web build, CDN, edge/serverless APIs | **Vercel**                                          | Auto‑pulls from GitHub, zero‑config CDN, built‑in Cron and secrets |
-| iOS/Android binaries & OTA updates   | **Expo EAS Build + EAS Update**                     | Cloud Mac/Linux workers, store submit, one‑click OTA patches       |
+| Android binaries & OTA updates       | **Expo EAS Build + EAS Update**                     | Cloud Linux workers, Play Store submit, one-click OTA patches      |
 | Database-local jobs                  | **Supabase Edge Function** scheduled via `pg_cron`  | 0 ms latency to Postgres; secrets stored in Vault                  |
 | Long/heavy workflows                 | **GitHub Actions**                                  | Up to 72 h on hosted runners, 5‑min cron granularity               |
 | Optional extra cron capacity         | Cloudflare Workers, Railway, Render, Upstash QStash | Use if you need per‑minute triggers or already pay those vendors   |

--- a/app.config.ts
+++ b/app.config.ts
@@ -9,17 +9,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   android: {
     package: process.env.ANDROID_PACKAGE || "com.maidenfan.powerpick",
   },
-  ios: {
-    bundleIdentifier:
-      process.env.IOS_BUNDLE_IDENTIFIER || "com.maidenfan.powerpick",
-          infoPlist: {
-      /**
-       * false = “My app does NOT use non-exempt encryption”
-       * true  = “My app DOES use it” (rare for JS/TS apps)
-       */
-      ITSAppUsesNonExemptEncryption: false,
-   },     
-  },
 
   // your existing fields
   name: config.name!,

--- a/app.json
+++ b/app.json
@@ -13,9 +13,6 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "ios": {
-      "supportsTablet": true
-    },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
@@ -28,14 +25,8 @@
       "bundler": "metro",
       "output": "static"
     },
-    "plugins": [
-      "expo-router"
-    ],
-    "platforms": [
-      "ios",
-      "android",
-      "web"
-    ],
+    "plugins": ["expo-router"],
+    "platforms": ["android", "web"],
     "extra": {
       "EXPO_PUBLIC_SUPABASE_URL": "https://damfzsmplbsbraqcmagv.supabase.co",
       "EXPO_PUBLIC_SUPABASE_ANON_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRhbWZ6c21wbGJzYnJhcWNtYWd2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAxNTQwMzMsImV4cCI6MjA2NTczMDAzM30._LfMdf8vPvwfzfnQbAqkEX7OiZyPaVdsKr9VlhUT-UM",

--- a/eas.json
+++ b/eas.json
@@ -2,8 +2,7 @@
   "cli": { "version": "^16.13.4" },
   "build": {
     "production": {
-      "android": {},
-      "ios": {}
+      "android": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",
-    "ios": "expo start --ios",
     "web": "expo start --web",
     "lint": "cross-env ESLINT_USE_FLAT_CONFIG=true eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "cross-env ESLINT_USE_FLAT_CONFIG=true eslint --ext .js,.jsx,.ts,.tsx . --fix",


### PR DESCRIPTION
## Summary
- drop iOS configuration from Expo project
- remove iOS build steps from CI workflow
- document that iOS is planned for later

## Testing
- `yarn lint`
- `yarn format:check`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6869c6f81058832fb1192e52256dfaa8