### PR TITLE
Fix theme context by using Expo Router entry

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -3,19 +3,19 @@ import { useEffect, useState, useMemo } from "react";
 import { StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { StatusBar } from "expo-status-bar";
-import RegionPicker from "./src/components/RegionPicker";
-import ComingSoon from "./src/components/ComingSoon";
-import GameGrid from "./src/components/GameGrid";
-import { SCREEN_BG } from "./src/lib/constants";
-import { useTheme } from "./src/lib/theme";
-import { Game, fetchGames } from "./src/lib/gamesApi";
+import RegionPicker from "../src/components/RegionPicker";
+import ComingSoon from "../src/components/ComingSoon";
+import GameGrid from "../src/components/GameGrid";
+import { SCREEN_BG } from "../src/lib/constants";
+import { useTheme } from "../src/lib/theme";
+import { Game, fetchGames } from "../src/lib/gamesApi";
 import { useRouter } from "expo-router";
-import { useGamesStore } from "./src/stores/useGamesStore";
-import { useRegionStore } from "./src/stores/useRegionStore";
+import { useGamesStore } from "../src/stores/useGamesStore";
+import { useRegionStore } from "../src/stores/useRegionStore";
 import {
   REGION_PLACEHOLDER_IMAGES,
   REGION_LABELS,
-} from "./src/lib/regionConfig";
+} from "../src/lib/regionConfig";
 
 export default function IndexScreen() {
   const { tokens } = useTheme();

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,1 @@
-import { registerRootComponent } from 'expo';
-
-import App from './App';
-
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
-registerRootComponent(App);
+import 'expo-router/entry';


### PR DESCRIPTION
## Summary
- use expo-router entry as the native entry point
- move `App.tsx` into `app/index.tsx`
- adjust imports after moving the file

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react', etc.)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686bc88285ac832fac90b8efa3a8d352