### PR TITLE
Add FastAPI bell curve storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@
 - **Cross‑platform client** – One React Native + Expo code‑base ships to iOS / Android / Web.  
 - **Realtime data** – Nightly draws imported via `pg_net` HTTP calls scheduled with `pg_cron`, all inside Postgres.  
 - **JWT auth & rate‑limits** – Secure every write route; tokens issued by Supabase Auth and validated in FastAPI middleware.  
-- **Hot & cold stats** – Materialised views refresh after each import for instant “trending numbers” insights.  
-- **Fully tested** – PyTest + `TestClient` cover the API and keep regressions out of prod.  
+- **Hot & cold stats** – Materialised views refresh after each import for instant “trending numbers” insights.
+- **Bell‑curve predictions** – Results are stored in Supabase for later analysis.
+- **Fully tested** – PyTest + `TestClient` cover the API and keep regressions out of prod.
 
 ---
 
@@ -43,7 +44,7 @@ Expo App (RN)  ─┬─>  /api/predict   ┐
        Supabase Auth ─── JWT ────> │
                                    │
                 Postgres (Supabase)│
-                ├─ tables: games, draws, results
+                ├─ tables: games, draws, results, bell_curve_predictions
                 ├─ ext: pg_cron, pg_net
                 └─ materialised views
 ```
@@ -81,7 +82,7 @@ supabase db push       # runs /db/migrations/*.sql
 
 The migrations create:
 
-* Core tables (`games`, `draws`, `draw_results`, `predictions`)  
+* Core tables (`games`, `draws`, `draw_results`, `bell_curve_predictions`)
 * Extensions: `pgcrypto`, `pg_cron`, `pg_net`  
 * RLS policies giving **read‑only** access to the public API
 
@@ -121,7 +122,7 @@ Nightly draws import via a `pg_cron` job (`import_draws.sql`) that calls `SELECT
 ## API Reference
 | Route | Method | Auth | Description |
 |-------|--------|------|-------------|
-| `/api/predict` | `POST` | JWT | Returns a single pick using the bell‑curve algorithm |
+| `/api/predict` | `POST` | JWT | Returns a single pick using the bell‑curve algorithm and stores it |
 | `/api/stats` | `GET` | Public | Hot, cold, overdue numbers |
 | `/api/history` | `GET` | JWT | User’s past predictions |
 

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,40 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import os
+import numpy as np
+from scipy.stats import norm
+from supabase import create_client, Client
+
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_ANON_KEY")
+
+supabase: Client | None = None
+if SUPABASE_URL and SUPABASE_KEY:
+    supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+app = FastAPI()
+
+class DrawData(BaseModel):
+    game_id: str
+    draws: list[int]
+
+@app.post("/predict")
+def predict(data: DrawData):
+    draws = data.draws
+    if not draws:
+        predicted_numbers: list[int] = []
+    else:
+        mean = float(np.mean(draws))
+        std_dev = float(np.std(draws)) or 1.0
+        x = np.arange(1, 91)
+        lower_bound = norm.ppf(0.15, mean, std_dev)
+        upper_bound = norm.ppf(0.85, mean, std_dev)
+        predicted_numbers = [int(num) for num in x if lower_bound <= num <= upper_bound]
+
+    if supabase:
+        supabase.table("bell_curve_predictions").insert({
+            "game_id": data.game_id,
+            "predicted_numbers": predicted_numbers
+        }).execute()
+
+    return {"predicted_numbers": predicted_numbers}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+numpy
+scipy
+supabase_py

--- a/supabase/migrations/base_table_setup.sql
+++ b/supabase/migrations/base_table_setup.sql
@@ -185,6 +185,23 @@ GRANT SELECT ON public.hot_cold_numbers TO anon,authenticated;
 GRANT INSERT,UPDATE,DELETE ON public.hot_cold_numbers TO service_role;
 
 -- -------------------------------------------------------------------
+-- Bell curve predictions
+-- -------------------------------------------------------------------
+CREATE TABLE public.bell_curve_predictions (
+  id               SERIAL PRIMARY KEY,
+  game_id          UUID NOT NULL REFERENCES public.games(id) ON DELETE CASCADE,
+  predicted_numbers INT[] NOT NULL,
+  created_at       TIMESTAMPTZ DEFAULT now()
+);
+ALTER TABLE public.bell_curve_predictions ENABLE ROW LEVEL SECURITY;
+CREATE POLICY bell_curve_read ON public.bell_curve_predictions
+  FOR SELECT TO anon,authenticated USING (true);
+CREATE POLICY bell_curve_rw_service ON public.bell_curve_predictions
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+GRANT SELECT ON public.bell_curve_predictions TO anon,authenticated;
+GRANT INSERT,UPDATE,DELETE ON public.bell_curve_predictions TO service_role;
+
+-- -------------------------------------------------------------------
 -- Helper: weekday name → int
 -- -------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.dow_from_dayname(p_day TEXT)


### PR DESCRIPTION
## Summary
- store bell curve predictions in a new Supabase table
- expose a minimal FastAPI server that writes predictions
- document bell-curve features in README
- update migration script with new table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686e681be8d8832f8e3e2afc7eb2fc66