### PR TITLE
Add unit tests for parser and utilities

### DIFF
--- a/src/lib/__tests__/csvParser.test.ts
+++ b/src/lib/__tests__/csvParser.test.ts
@@ -1,0 +1,19 @@
+import { csvParse, csvParseRows } from "../csvParser";
+
+describe("csv parsing utilities", () => {
+  test("csvParse converts CSV text to objects", () => {
+    const text = "a,b\n1,2\n3,4";
+    expect(csvParse(text)).toEqual([
+      { a: "1", b: "2" },
+      { a: "3", b: "4" },
+    ]);
+  });
+
+  test("csvParseRows handles quoted values with commas", () => {
+    const text = 'a,b\n"1,1",2';
+    expect(csvParseRows(text)).toEqual([
+      ["a", "b"],
+      ["1,1", "2"],
+    ]);
+  });
+});

--- a/src/lib/__tests__/generator.test.ts
+++ b/src/lib/__tests__/generator.test.ts
@@ -1,0 +1,17 @@
+import { generateSet } from "../generator";
+
+describe("generateSet", () => {
+  test("throws when pickCount exceeds maxNumber", () => {
+    expect(() => generateSet({ maxNumber: 2, pickCount: 3 })).toThrow(
+      "pickCount cannot exceed maxNumber",
+    );
+  });
+
+  test("generates deterministic set with custom rand", () => {
+    const result = generateSet(
+      { maxNumber: 5, pickCount: 3, windowPct: 1 },
+      () => 0,
+    );
+    expect(result).toEqual([1, 2, 3]);
+  });
+});

--- a/src/lib/__tests__/hotCold.test.ts
+++ b/src/lib/__tests__/hotCold.test.ts
@@ -1,0 +1,13 @@
+import { calculateHotColdNumbers } from "../hotCold";
+
+describe("calculateHotColdNumbers", () => {
+  test("returns hot and cold numbers based on draw history", () => {
+    const draws = [
+      [1, 2, 3],
+      [1, 3, 5],
+      [2, 3, 4],
+    ];
+    const result = calculateHotColdNumbers(draws, 5, 20);
+    expect(result).toEqual({ hot: [3], cold: [5] });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest unit tests for number generation
- test hot/cold number calculation
- cover CSV parsing helpers

## Testing
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686fab6d04a4832fb10d18f8a9f2116b