### PR TITLE
Implement explicit Supabase read/write keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,13 @@ supabase start   # spins up Postgres with pg_cron & pg_net
 cp .env.example .env.local
 ```
 
-Populate the `.env.local` file with your Supabase URL, anon key, and service‑role key—Vercel injects these automatically in prod.
+Populate the `.env.local` file with your Supabase URL plus separate read and write keys. The read key usually matches Supabase's anon key, while the write key should be the service role key. Vercel injects these automatically in prod.
+
+Required variables:
+
+- `SUPABASE_URL`
+- `SUPABASE_READ_KEY` *(fallback `SUPABASE_ANON_KEY`)*
+- `SUPABASE_WRITE_KEY` *(fallback `SUPABASE_SERVICE_ROLE_KEY`)*
 
 ### Database setup
 

--- a/api/main.py
+++ b/api/main.py
@@ -6,8 +6,11 @@ import numpy as np
 from scipy.stats import norm
 from supabase import create_client, Client
 
+# Prefer explicit read/write keys with service role as fallback
 SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_ANON_KEY")
+SUPABASE_READ_KEY = os.getenv("SUPABASE_READ_KEY") or os.getenv("SUPABASE_ANON_KEY")
+SUPABASE_WRITE_KEY = os.getenv("SUPABASE_WRITE_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+SUPABASE_KEY = SUPABASE_WRITE_KEY or SUPABASE_READ_KEY
 
 supabase: Client | None = None
 if SUPABASE_URL and SUPABASE_KEY:

--- a/src/generation/weight_generation.py
+++ b/src/generation/weight_generation.py
@@ -15,13 +15,15 @@ from datetime import datetime
 import requests
 
 # ──────────── Configuration ────────────
-# Supabase connection details. Use service role if available.
+# Supabase connection details. Prefer explicit keys with service role fallback.
 SUPABASE_URL = os.getenv("SUPABASE_URL") or os.getenv("EXPO_PUBLIC_SUPABASE_URL")
-SUPABASE_KEY = (
-    os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+READ_KEY = (
+    os.getenv("SUPABASE_READ_KEY")
     or os.getenv("SUPABASE_ANON_KEY")
     or os.getenv("EXPO_PUBLIC_SUPABASE_ANON_KEY")
 )
+WRITE_KEY = os.getenv("SUPABASE_WRITE_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+SUPABASE_KEY = WRITE_KEY or READ_KEY
 
 DECAY_HALF_LIFE = int(os.getenv("DECAY_HALF_LIFE", "120"))  # in draws
 GAME_UUID = os.getenv("GAME_UUID")

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -7,15 +7,22 @@ import Constants from "expo-constants";
 const extra = Constants.expoConfig?.extra ?? {};
 const EXPO_PUBLIC_SUPABASE_URL =
   extra.EXPO_PUBLIC_SUPABASE_URL || process.env.EXPO_PUBLIC_SUPABASE_URL;
-const EXPO_PUBLIC_SUPABASE_ANON_KEY =
+const READ_KEY =
+  extra.EXPO_PUBLIC_SUPABASE_READ_KEY ||
+  process.env.EXPO_PUBLIC_SUPABASE_READ_KEY ||
   extra.EXPO_PUBLIC_SUPABASE_ANON_KEY ||
   process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+const WRITE_KEY =
+  extra.EXPO_PUBLIC_SUPABASE_WRITE_KEY ||
+  process.env.EXPO_PUBLIC_SUPABASE_WRITE_KEY;
 
-if (!EXPO_PUBLIC_SUPABASE_URL || !EXPO_PUBLIC_SUPABASE_ANON_KEY) {
+const SUPABASE_KEY = READ_KEY || WRITE_KEY;
+
+if (!EXPO_PUBLIC_SUPABASE_URL || !SUPABASE_KEY) {
   const missing = [];
   if (!EXPO_PUBLIC_SUPABASE_URL) missing.push("EXPO_PUBLIC_SUPABASE_URL");
-  if (!EXPO_PUBLIC_SUPABASE_ANON_KEY)
-    missing.push("EXPO_PUBLIC_SUPABASE_ANON_KEY");
+  if (!READ_KEY && !WRITE_KEY)
+    missing.push("EXPO_PUBLIC_SUPABASE_READ_KEY or EXPO_PUBLIC_SUPABASE_WRITE_KEY");
   throw new Error(
     `Supabase credentials missing. Please set ${missing.join(
       " and ",
@@ -25,5 +32,5 @@ if (!EXPO_PUBLIC_SUPABASE_URL || !EXPO_PUBLIC_SUPABASE_ANON_KEY) {
 
 export const supabase = createClient(
   EXPO_PUBLIC_SUPABASE_URL,
-  EXPO_PUBLIC_SUPABASE_ANON_KEY,
+  SUPABASE_KEY,
 );

--- a/src/lib/syncDraws.ts
+++ b/src/lib/syncDraws.ts
@@ -12,13 +12,16 @@ dotenv.config();
 // 2) Read and validate env vars
 const SUPABASE_URL: string =
   process.env.SUPABASE_URL ?? process.env.EXPO_PUBLIC_SUPABASE_URL ?? "";
-const SUPABASE_ANON_KEY: string =
+const SUPABASE_READ_KEY: string =
+  process.env.SUPABASE_READ_KEY ??
   process.env.SUPABASE_ANON_KEY ??
   process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ??
   "";
-const SUPABASE_SERVICE_ROLE_KEY: string =
-  process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
-const supabaseKey: string = SUPABASE_SERVICE_ROLE_KEY || SUPABASE_ANON_KEY;
+const SUPABASE_WRITE_KEY: string =
+  process.env.SUPABASE_WRITE_KEY ??
+  process.env.SUPABASE_SERVICE_ROLE_KEY ??
+  "";
+const supabaseKey: string = SUPABASE_WRITE_KEY || SUPABASE_READ_KEY;
 
 if (!SUPABASE_URL || !supabaseKey) {
   throw new Error("Supabase credentials are missing");
@@ -26,13 +29,10 @@ if (!SUPABASE_URL || !supabaseKey) {
 
 // 3) Debug credentials (show which key is used)
 log("DEBUG: SUPABASE_URL  =", SUPABASE_URL);
-if (SUPABASE_SERVICE_ROLE_KEY) {
-  log(
-    "DEBUG: Using service role key",
-    SUPABASE_SERVICE_ROLE_KEY.slice(0, 4) + "...",
-  );
+if (SUPABASE_WRITE_KEY) {
+  log("DEBUG: Using write key", SUPABASE_WRITE_KEY.slice(0, 4) + "...");
 } else {
-  log("DEBUG: Using anon key", SUPABASE_ANON_KEY.slice(0, 4) + "...");
+  log("DEBUG: Using read key", SUPABASE_READ_KEY.slice(0, 4) + "...");
 }
 
 // 4) Initialize Supabase client

--- a/src/lib/syncHotCold.ts
+++ b/src/lib/syncHotCold.ts
@@ -9,11 +9,14 @@ let supabase: SupabaseClient;
 function initSupabase(): void {
   const SUPABASE_URL =
     process.env.SUPABASE_URL ?? process.env.EXPO_PUBLIC_SUPABASE_URL;
-  // Use the service role key for backend sync to bypass RLS
-  const SUPABASE_KEY =
-    process.env.SUPABASE_SERVICE_ROLE_KEY ??
+  const READ_KEY =
+    process.env.SUPABASE_READ_KEY ??
     process.env.SUPABASE_ANON_KEY ??
     process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+  const WRITE_KEY =
+    process.env.SUPABASE_WRITE_KEY ??
+    process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const SUPABASE_KEY = WRITE_KEY || READ_KEY;
   if (!SUPABASE_URL || !SUPABASE_KEY) {
     throw new Error("Supabase credentials are missing");
   }


### PR DESCRIPTION
## Summary
- allow front-end to read SUPABASE_READ_KEY or SUPABASE_WRITE_KEY
- update backend scripts to prefer explicit read & write keys
- document new environment variables in README

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm run type-check` *(fails: missing React Native deps)*
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_686fbaa9ca78832f89febe6ed9453c99