### PR TITLE
Add bell curve chart for draw sum frequency

### DIFF
--- a/src/components/__tests__/BellCurveChart.test.tsx
+++ b/src/components/__tests__/BellCurveChart.test.tsx
@@ -1,13 +1,19 @@
 import React from "react";
 import { render } from "@testing-library/react-native";
 import BellCurveChart from "../BellCurveChart";
+import { Bucket } from "../../lib/buildSumBuckets";
 
 test("renders bars and axis labels", () => {
+  const buckets: Bucket[] = [
+    { label: "0-4", mid: 2.5, freq: 10 },
+    { label: "5-9", mid: 7.5, freq: 20 },
+    { label: "10-14", mid: 12.5, freq: 30 },
+  ];
   const { getAllByLabelText, getByText } = render(
-    <BellCurveChart counts={[10, 20, 30]} />,
+    <BellCurveChart buckets={buckets} />,
   );
-  expect(getAllByLabelText("count bar").length).toBe(3);
-  getByText("1");
-  getByText("2");
-  getByText("3");
+  expect(getAllByLabelText("histogram bar").length).toBe(3);
+  getByText("0-4");
+  getByText("5-9");
+  getByText("10-14");
 });

--- a/src/lib/__tests__/__snapshots__/buildSumBuckets.test.ts.snap
+++ b/src/lib/__tests__/__snapshots__/buildSumBuckets.test.ts.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`builds correct bucket frequencies 1`] = `
+[
+  {
+    "freq": 1,
+    "label": "20-29",
+    "mid": 25,
+  },
+  {
+    "freq": 0,
+    "label": "30-39",
+    "mid": 35,
+  },
+  {
+    "freq": 0,
+    "label": "40-49",
+    "mid": 45,
+  },
+  {
+    "freq": 0,
+    "label": "50-59",
+    "mid": 55,
+  },
+  {
+    "freq": 0,
+    "label": "60-69",
+    "mid": 65,
+  },
+  {
+    "freq": 0,
+    "label": "70-79",
+    "mid": 75,
+  },
+  {
+    "freq": 0,
+    "label": "80-89",
+    "mid": 85,
+  },
+  {
+    "freq": 0,
+    "label": "90-99",
+    "mid": 95,
+  },
+  {
+    "freq": 0,
+    "label": "100-109",
+    "mid": 105,
+  },
+  {
+    "freq": 0,
+    "label": "110-119",
+    "mid": 115,
+  },
+  {
+    "freq": 0,
+    "label": "120-129",
+    "mid": 125,
+  },
+  {
+    "freq": 0,
+    "label": "130-139",
+    "mid": 135,
+  },
+  {
+    "freq": 0,
+    "label": "140-149",
+    "mid": 145,
+  },
+  {
+    "freq": 0,
+    "label": "150-159",
+    "mid": 155,
+  },
+  {
+    "freq": 0,
+    "label": "160-169",
+    "mid": 165,
+  },
+  {
+    "freq": 0,
+    "label": "170-179",
+    "mid": 175,
+  },
+  {
+    "freq": 0,
+    "label": "180-189",
+    "mid": 185,
+  },
+  {
+    "freq": 0,
+    "label": "190-199",
+    "mid": 195,
+  },
+  {
+    "freq": 0,
+    "label": "200-209",
+    "mid": 205,
+  },
+  {
+    "freq": 0,
+    "label": "210-219",
+    "mid": 215,
+  },
+  {
+    "freq": 1,
+    "label": "220-229",
+    "mid": 225,
+  },
+  {
+    "freq": 0,
+    "label": "230-239",
+    "mid": 235,
+  },
+]
+`;

--- a/src/lib/__tests__/buildSumBuckets.test.ts
+++ b/src/lib/__tests__/buildSumBuckets.test.ts
@@ -1,0 +1,10 @@
+import { buildSumBuckets } from "../buildSumBuckets";
+
+test("builds correct bucket frequencies", () => {
+  const draws = [
+    [1, 2, 3, 4, 5, 6, 7],
+    [35, 34, 33, 32, 31, 30, 29],
+  ];
+  const buckets = buildSumBuckets(draws, 10);
+  expect(buckets).toMatchSnapshot();
+});

--- a/src/lib/buildSumBuckets.ts
+++ b/src/lib/buildSumBuckets.ts
@@ -1,0 +1,33 @@
+export interface Bucket {
+  label: string;
+  mid: number;
+  freq: number;
+}
+
+export function buildSumBuckets(draws: number[][], binSize = 5): Bucket[] {
+  if (!draws.length) return [];
+
+  const sums = draws.map((d) => d.reduce((a, b) => a + b, 0));
+  const min = Math.min(...sums);
+  const max = Math.max(...sums);
+
+  const firstBinStart = Math.floor(min / binSize) * binSize;
+  const lastBinStart = Math.ceil(max / binSize) * binSize;
+
+  const bucketStarts: number[] = [];
+  for (let s = firstBinStart; s <= lastBinStart; s += binSize) {
+    bucketStarts.push(s);
+  }
+
+  const freqs = Array(bucketStarts.length).fill(0);
+  sums.forEach((sum) => {
+    const idx = Math.floor((sum - firstBinStart) / binSize);
+    freqs[idx] += 1;
+  });
+
+  return bucketStarts.map((start, i) => ({
+    label: `${start}-${start + binSize - 1}`,
+    mid: start + binSize / 2,
+    freq: freqs[i],
+  }));
+}


### PR DESCRIPTION
## Summary
- add `buildSumBuckets` util to bucket draw sums
- replace `BellCurveChart` with histogram + gaussian overlay
- update bell curve screen to use sum buckets
- test new utility and chart component

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6870c88c10d8832fbedab23d9eeb8674