### PR TITLE
Fix bell curve draw range

### DIFF
--- a/src/components/BellCurveChart.tsx
+++ b/src/components/BellCurveChart.tsx
@@ -103,7 +103,12 @@ export default function BellCurveChart({
 }
 
 const styles = StyleSheet.create({
-  wrapper: { width: "100%", paddingBottom: 24 },
+  wrapper: {
+    width: "100%",
+    paddingBottom: 24,
+    flexDirection: "row",
+    alignItems: "flex-end",
+  },
   barContainer: { alignItems: "center", justifyContent: "flex-end" },
   axis: { flexDirection: "row", flexWrap: "wrap" },
   axisLabel: {

--- a/src/lib/__tests__/gamesApi.test.ts
+++ b/src/lib/__tests__/gamesApi.test.ts
@@ -1,0 +1,29 @@
+import { fetchRecentDraws, _clearCaches } from "../gamesApi";
+import { supabase } from "../supabase";
+
+jest.mock("../supabase", () => ({
+  supabase: { from: jest.fn() },
+}));
+
+describe("fetchRecentDraws", () => {
+  beforeEach(() => {
+    _clearCaches();
+    jest.clearAllMocks();
+  });
+
+  test("returns all draw rows in descending order", async () => {
+    const rows = [
+      { draw_number: 2, draw_date: "2024-01-02", draw_results: [] },
+      { draw_number: 1, draw_date: "2024-01-01", draw_results: [] },
+    ];
+    const mockOrder = jest.fn().mockResolvedValue({ data: rows, error: null });
+    (supabase.from as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      order: mockOrder,
+    });
+    const result = await fetchRecentDraws("g1", true);
+    expect(result).toHaveLength(2);
+    expect(mockOrder).toHaveBeenCalledWith("draw_number", { ascending: false });
+  });
+});

--- a/src/lib/gamesApi.ts
+++ b/src/lib/gamesApi.ts
@@ -171,8 +171,7 @@ export async function fetchRecentDraws(
     .from("draws")
     .select("draw_number, draw_date, draw_results(number, ball_types(name))")
     .eq("game_id", gameId)
-    .order("draw_number", { ascending: false })
-    .limit(10);
+    .order("draw_number", { ascending: false });
   if (error) {
     console.error("Error fetching draws:", error);
     throw error;


### PR DESCRIPTION
## Summary
- remove hard limit on fetchRecentDraws
- cover new behaviour with tests

## Checklist
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test`
- [x] `pytest`


------
https://chatgpt.com/codex/tasks/task_e_687190d689f0832f96ba2479c77a0195